### PR TITLE
Add generator for Arguments class and for Query class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.3.0 BREAKING
+- Add new generators to GraphQLQuery and QueryArguments
+- Fix toJson() on JsonSerializable classes (for nested entities)
+- [BREAKING] Remove the `execute*` functions generations, to use instead the generic `ArtemisClient` class
+that should receive a GraphQLQuery generated subclass.
+
 ## 0.2.0 BREAKING
 Completely overhaul how this works.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ targets:
 
 | Option | Default value | Description |
 | - | - | - |
-| `generate_helpers` | `true` | If Artemis should generate query/mutation helper functions (with inputs and coercing). |
+| `generate_helpers` | `true` | If Artemis should generate query/mutation helper GraphQLQuery subclass. |
 | `custom_parser_import` | `null` | Import path to the file implementing coercer functions for custom scalars. See [Custom scalars](#custom-scalars). |
 | `scalar_mapping` | `[]` | Mapping of GraphQL and Dart types. See [Custom scalars](#custom-scalars). |
 | `schema_mapping` | `[]` | Mapping of queries and which schemas they will use for code generation. See [Schema mapping](#schema-mapping). |
@@ -107,3 +107,15 @@ Each `ScalarMap` is configured this way:
 | `use_custom_parser` | `false` | Wheter `custom_parser_import` should be imported on the beginning of the file. |
 
 See [examples](./example) for more information and configuration options.
+
+## **ArtemisClient**
+If you have `generate_helpers` then, Artemis will create a subclass of `GraphQLQuery` for you, this class can be used
+in conjunction with the `ArtemisClient` found at: `package:artemis/client.dart`.
+
+```dart
+final client = ArtemisClient();
+final gitHubReposQuery = MyGitHubReposQuery();
+final response = await client.query(gitHubReposQuery);
+```
+ 
+Check the [examples](./example) to seehow to use it in details.

--- a/example/graphbrainz/lib/main.dart
+++ b/example/graphbrainz/lib/main.dart
@@ -1,9 +1,13 @@
 import 'dart:async';
 import 'package:graphbrainz_example/queries/ed_sheeran.query.dart';
+import 'package:artemis/client.dart';
 
 Future<void> main() async {
   const graphQLEndpoint = 'https://graphbrainz.herokuapp.com/';
-  final response = await executeEdSheeranQuery(graphQLEndpoint);
+  final client = ArtemisClient(graphQLEndpoint);
+
+  final query = EdSheeranQuery();
+  final response = await client.execute(query);
 
   if (response.hasErrors) {
     return print('Error: ${response.errors.map((e) => e.message).toList()}');

--- a/example/graphbrainz/lib/queries/ed_sheeran.query.dart
+++ b/example/graphbrainz/lib/queries/ed_sheeran.query.dart
@@ -102,7 +102,7 @@ class Entity {
   Map<String, dynamic> toJson() => _$EntityToJson(this);
 }
 
-class EdSheeranQuery extends GraphQLQuery<EdSheeran> {
+class EdSheeranQuery extends GraphQLQuery<EdSheeran, void> {
   EdSheeranQuery();
 
   @override

--- a/example/graphbrainz/lib/queries/ed_sheeran.query.dart
+++ b/example/graphbrainz/lib/queries/ed_sheeran.query.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:json_annotation/json_annotation.dart';
 import 'package:graphbrainz_example/coercers.dart';
+import 'package:artemis/schema/graphql_query.dart';
 import 'package:artemis/schema/graphql_error.dart';
 
 part 'ed_sheeran.query.g.dart';
@@ -101,6 +102,19 @@ class Entity {
   Map<String, dynamic> toJson() => _$EntityToJson(this);
 }
 
+class EdSheeranQuery extends GraphQLQuery<EdSheeran> {
+  EdSheeranQuery();
+
+  @override
+  final String query =
+      'query ed_sheeran { node(id: "QXJ0aXN0OmI4YTdjNTFmLTM2MmMtNGRjYi1hMjU5LWJjNmUwMDk1ZjBhNg==") { __typename id ... on Artist { mbid name lifeSpan { begin } spotify { href } } } }';
+
+  @override
+  EdSheeran parse(Map<String, dynamic> json) {
+    return EdSheeran.fromJson(json);
+  }
+}
+
 Future<GraphQLResponse<EdSheeran>> executeEdSheeranQuery(String graphQLEndpoint,
     {http.Client client}) async {
   final httpClient = client ?? http.Client();
@@ -111,15 +125,17 @@ Future<GraphQLResponse<EdSheeran>> executeEdSheeranQuery(String graphQLEndpoint,
       'query':
           'query ed_sheeran { node(id: "QXJ0aXN0OmI4YTdjNTFmLTM2MmMtNGRjYi1hMjU5LWJjNmUwMDk1ZjBhNg==") { __typename id ... on Artist { mbid name lifeSpan { begin } spotify { href } } } }',
     }),
-    headers: {
-      'Content-type': 'application/json',
-      'Accept': 'application/json',
-    },
+    headers: (client != null)
+        ? null
+        : {
+            'Content-type': 'application/json',
+            'Accept': 'application/json',
+          },
   );
 
-  final jsonBody = json.decode(dataResponse.body);
+  final Map<String, dynamic> jsonBody = json.decode(dataResponse.body);
   final response = GraphQLResponse<EdSheeran>.fromJson(jsonBody)
-    ..data = EdSheeran.fromJson(jsonBody['data'] ?? {});
+    ..data = EdSheeran.fromJson(jsonBody['data'] ?? <Map<String, dynamic>>{});
 
   if (client == null) {
     httpClient.close();

--- a/example/graphbrainz/lib/queries/ed_sheeran.query.dart
+++ b/example/graphbrainz/lib/queries/ed_sheeran.query.dart
@@ -10,7 +10,7 @@ import 'package:artemis/schema/graphql_error.dart';
 
 part 'ed_sheeran.query.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class EdSheeran {
   Node node;
 
@@ -21,7 +21,7 @@ class EdSheeran {
   Map<String, dynamic> toJson() => _$EdSheeranToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Node {
   String id;
   @JsonKey(name: '__typename')
@@ -47,7 +47,7 @@ class Node {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Artist implements Node, Entity {
   String mbid;
   String name;
@@ -65,7 +65,7 @@ class Artist implements Node, Entity {
   Map<String, dynamic> toJson() => _$ArtistToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class LifeSpan {
   @JsonKey(
       fromJson: fromGraphQLDateToDartDateTime,
@@ -79,7 +79,7 @@ class LifeSpan {
   Map<String, dynamic> toJson() => _$LifeSpanToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SpotifyArtist {
   String href;
 
@@ -90,7 +90,7 @@ class SpotifyArtist {
   Map<String, dynamic> toJson() => _$SpotifyArtistToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Entity {
   String mbid;
   @JsonKey(name: '__typename')
@@ -102,44 +102,17 @@ class Entity {
   Map<String, dynamic> toJson() => _$EntityToJson(this);
 }
 
-class EdSheeranQuery extends GraphQLQuery<EdSheeran, void> {
+class EdSheeranQuery extends GraphQLQuery<EdSheeran, JsonSerializable> {
   EdSheeranQuery();
 
   @override
   final String query =
       'query ed_sheeran { node(id: "QXJ0aXN0OmI4YTdjNTFmLTM2MmMtNGRjYi1hMjU5LWJjNmUwMDk1ZjBhNg==") { __typename id ... on Artist { mbid name lifeSpan { begin } spotify { href } } } }';
+  @override
+  final String operationName = 'ed_sheeran';
 
   @override
   EdSheeran parse(Map<String, dynamic> json) {
     return EdSheeran.fromJson(json);
   }
-}
-
-Future<GraphQLResponse<EdSheeran>> executeEdSheeranQuery(String graphQLEndpoint,
-    {http.Client client}) async {
-  final httpClient = client ?? http.Client();
-  final dataResponse = await httpClient.post(
-    graphQLEndpoint,
-    body: json.encode({
-      'operationName': 'ed_sheeran',
-      'query':
-          'query ed_sheeran { node(id: "QXJ0aXN0OmI4YTdjNTFmLTM2MmMtNGRjYi1hMjU5LWJjNmUwMDk1ZjBhNg==") { __typename id ... on Artist { mbid name lifeSpan { begin } spotify { href } } } }',
-    }),
-    headers: (client != null)
-        ? null
-        : {
-            'Content-type': 'application/json',
-            'Accept': 'application/json',
-          },
-  );
-
-  final Map<String, dynamic> jsonBody = json.decode(dataResponse.body);
-  final response = GraphQLResponse<EdSheeran>.fromJson(jsonBody)
-    ..data = EdSheeran.fromJson(jsonBody['data'] ?? <Map<String, dynamic>>{});
-
-  if (client == null) {
-    httpClient.close();
-  }
-
-  return response;
 }

--- a/example/graphbrainz/lib/queries/ed_sheeran.query.g.dart
+++ b/example/graphbrainz/lib/queries/ed_sheeran.query.g.dart
@@ -13,8 +13,9 @@ EdSheeran _$EdSheeranFromJson(Map<String, dynamic> json) {
         : Node.fromJson(json['node'] as Map<String, dynamic>);
 }
 
-Map<String, dynamic> _$EdSheeranToJson(EdSheeran instance) =>
-    <String, dynamic>{'node': instance.node};
+Map<String, dynamic> _$EdSheeranToJson(EdSheeran instance) => <String, dynamic>{
+      'node': instance.node,
+    };
 
 Node _$NodeFromJson(Map<String, dynamic> json) {
   return Node()
@@ -22,8 +23,10 @@ Node _$NodeFromJson(Map<String, dynamic> json) {
     ..resolveType = json['__typename'] as String;
 }
 
-Map<String, dynamic> _$NodeToJson(Node instance) =>
-    <String, dynamic>{'id': instance.id, '__typename': instance.resolveType};
+Map<String, dynamic> _$NodeToJson(Node instance) => <String, dynamic>{
+      'id': instance.id,
+      '__typename': instance.resolveType,
+    };
 
 Artist _$ArtistFromJson(Map<String, dynamic> json) {
   return Artist()
@@ -45,7 +48,7 @@ Map<String, dynamic> _$ArtistToJson(Artist instance) => <String, dynamic>{
       'lifeSpan': instance.lifeSpan,
       'spotify': instance.spotify,
       '__typename': instance.resolveType,
-      'id': instance.id
+      'id': instance.id,
     };
 
 LifeSpan _$LifeSpanFromJson(Map<String, dynamic> json) {
@@ -53,15 +56,18 @@ LifeSpan _$LifeSpanFromJson(Map<String, dynamic> json) {
     ..begin = fromGraphQLDateToDartDateTime(json['begin'] as String);
 }
 
-Map<String, dynamic> _$LifeSpanToJson(LifeSpan instance) =>
-    <String, dynamic>{'begin': fromDartDateTimeToGraphQLDate(instance.begin)};
+Map<String, dynamic> _$LifeSpanToJson(LifeSpan instance) => <String, dynamic>{
+      'begin': fromDartDateTimeToGraphQLDate(instance.begin),
+    };
 
 SpotifyArtist _$SpotifyArtistFromJson(Map<String, dynamic> json) {
   return SpotifyArtist()..href = json['href'] as String;
 }
 
 Map<String, dynamic> _$SpotifyArtistToJson(SpotifyArtist instance) =>
-    <String, dynamic>{'href': instance.href};
+    <String, dynamic>{
+      'href': instance.href,
+    };
 
 Entity _$EntityFromJson(Map<String, dynamic> json) {
   return Entity()
@@ -71,5 +77,5 @@ Entity _$EntityFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$EntityToJson(Entity instance) => <String, dynamic>{
       'mbid': instance.mbid,
-      '__typename': instance.resolveType
+      '__typename': instance.resolveType,
     };

--- a/example/graphbrainz/lib/queries/ed_sheeran.query.g.dart
+++ b/example/graphbrainz/lib/queries/ed_sheeran.query.g.dart
@@ -14,7 +14,7 @@ EdSheeran _$EdSheeranFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$EdSheeranToJson(EdSheeran instance) => <String, dynamic>{
-      'node': instance.node,
+      'node': instance.node?.toJson(),
     };
 
 Node _$NodeFromJson(Map<String, dynamic> json) {
@@ -45,8 +45,8 @@ Artist _$ArtistFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$ArtistToJson(Artist instance) => <String, dynamic>{
       'mbid': instance.mbid,
       'name': instance.name,
-      'lifeSpan': instance.lifeSpan,
-      'spotify': instance.spotify,
+      'lifeSpan': instance.lifeSpan?.toJson(),
+      'spotify': instance.spotify?.toJson(),
       '__typename': instance.resolveType,
       'id': instance.id,
     };

--- a/example/pokemon/lib/main.dart
+++ b/example/pokemon/lib/main.dart
@@ -2,12 +2,17 @@ import 'dart:async';
 
 import 'queries/big_query.query.dart';
 import 'queries/simple_query.query.dart';
+import 'package:artemis/client.dart';
 
 Future<void> main() async {
   const graphQLEndpoint = 'https://graphql-pokemon.now.sh/graphql';
+  final client = ArtemisClient(graphQLEndpoint);
 
-  final simpleQueryResponse = await executeSimpleQueryQuery(graphQLEndpoint);
-  final bigQueryResponse = await executeBigQueryQuery(graphQLEndpoint, 10);
+  final simpleQuery = SimpleQueryQuery();
+  final bigQuery = BigQueryQuery(variables: BigQueryArguments(quantity: 5));
+
+  final simpleQueryResponse = await client.execute(simpleQuery);
+  final bigQueryResponse = await client.execute(bigQuery);
 
   print('Simple query response: ${simpleQueryResponse.data.pokemon.number}');
 

--- a/example/pokemon/lib/queries/big_query.query.dart
+++ b/example/pokemon/lib/queries/big_query.query.dart
@@ -3,8 +3,8 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import 'package:artemis/schema/graphql_query.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:artemis/schema/graphql_query.dart';
 import 'package:artemis/schema/graphql_error.dart';
 
 part 'big_query.query.g.dart';
@@ -69,12 +69,10 @@ class BigQueryArguments {
   }
 }
 
-class BigQueryQuery extends GraphQLQuery<BigQuery> {
-  BigQueryQuery({BigQueryArguments arguments}) : variables = arguments.toMap();
-
+class BigQueryQuery extends GraphQLQuery<BigQuery, BigQueryArguments> {
+  BigQueryQuery({this.variables});
   @override
-  final Map<String, dynamic> variables;
-
+  final BigQueryArguments variables;
   @override
   final String query =
       'query big_query(\$quantity: Int!) { charmander: pokemon(name: "Charmander") { number types } pokemons(first: \$quantity) { number name types evolutions: evolutions { number name } } }';

--- a/example/pokemon/lib/queries/big_query.query.g.dart
+++ b/example/pokemon/lib/queries/big_query.query.g.dart
@@ -18,8 +18,8 @@ BigQuery _$BigQueryFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$BigQueryToJson(BigQuery instance) => <String, dynamic>{
-      'charmander': instance.charmander,
-      'pokemons': instance.pokemons,
+      'charmander': instance.charmander?.toJson(),
+      'pokemons': instance.pokemons?.map((e) => e?.toJson())?.toList(),
     };
 
 Charmander _$CharmanderFromJson(Map<String, dynamic> json) {
@@ -49,7 +49,7 @@ Map<String, dynamic> _$PokemonToJson(Pokemon instance) => <String, dynamic>{
       'number': instance.number,
       'name': instance.name,
       'types': instance.types,
-      'evolutions': instance.evolutions,
+      'evolutions': instance.evolutions?.map((e) => e?.toJson())?.toList(),
     };
 
 Evolutions _$EvolutionsFromJson(Map<String, dynamic> json) {
@@ -62,4 +62,15 @@ Map<String, dynamic> _$EvolutionsToJson(Evolutions instance) =>
     <String, dynamic>{
       'number': instance.number,
       'name': instance.name,
+    };
+
+BigQueryArguments _$BigQueryArgumentsFromJson(Map<String, dynamic> json) {
+  return BigQueryArguments(
+    quantity: json['quantity'] as int,
+  );
+}
+
+Map<String, dynamic> _$BigQueryArgumentsToJson(BigQueryArguments instance) =>
+    <String, dynamic>{
+      'quantity': instance.quantity,
     };

--- a/example/pokemon/lib/queries/big_query.query.g.dart
+++ b/example/pokemon/lib/queries/big_query.query.g.dart
@@ -19,7 +19,7 @@ BigQuery _$BigQueryFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$BigQueryToJson(BigQuery instance) => <String, dynamic>{
       'charmander': instance.charmander,
-      'pokemons': instance.pokemons
+      'pokemons': instance.pokemons,
     };
 
 Charmander _$CharmanderFromJson(Map<String, dynamic> json) {
@@ -29,7 +29,10 @@ Charmander _$CharmanderFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$CharmanderToJson(Charmander instance) =>
-    <String, dynamic>{'number': instance.number, 'types': instance.types};
+    <String, dynamic>{
+      'number': instance.number,
+      'types': instance.types,
+    };
 
 Pokemon _$PokemonFromJson(Map<String, dynamic> json) {
   return Pokemon()
@@ -46,7 +49,7 @@ Map<String, dynamic> _$PokemonToJson(Pokemon instance) => <String, dynamic>{
       'number': instance.number,
       'name': instance.name,
       'types': instance.types,
-      'evolutions': instance.evolutions
+      'evolutions': instance.evolutions,
     };
 
 Evolutions _$EvolutionsFromJson(Map<String, dynamic> json) {
@@ -56,4 +59,7 @@ Evolutions _$EvolutionsFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$EvolutionsToJson(Evolutions instance) =>
-    <String, dynamic>{'number': instance.number, 'name': instance.name};
+    <String, dynamic>{
+      'number': instance.number,
+      'name': instance.name,
+    };

--- a/example/pokemon/lib/queries/simple_query.query.dart
+++ b/example/pokemon/lib/queries/simple_query.query.dart
@@ -3,8 +3,8 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import 'package:artemis/schema/graphql_query.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:artemis/schema/graphql_query.dart';
 import 'package:artemis/schema/graphql_error.dart';
 
 part 'simple_query.query.g.dart';
@@ -32,7 +32,7 @@ class Pokemon {
   Map<String, dynamic> toJson() => _$PokemonToJson(this);
 }
 
-class SimpleQueryQuery extends GraphQLQuery<SimpleQuery> {
+class SimpleQueryQuery extends GraphQLQuery<SimpleQuery, void> {
   SimpleQueryQuery();
 
   @override

--- a/example/pokemon/lib/queries/simple_query.query.dart
+++ b/example/pokemon/lib/queries/simple_query.query.dart
@@ -9,7 +9,7 @@ import 'package:artemis/schema/graphql_error.dart';
 
 part 'simple_query.query.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SimpleQuery {
   Pokemon pokemon;
 
@@ -20,7 +20,7 @@ class SimpleQuery {
   Map<String, dynamic> toJson() => _$SimpleQueryToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Pokemon {
   String number;
   List<String> types;
@@ -32,45 +32,17 @@ class Pokemon {
   Map<String, dynamic> toJson() => _$PokemonToJson(this);
 }
 
-class SimpleQueryQuery extends GraphQLQuery<SimpleQuery, void> {
+class SimpleQueryQuery extends GraphQLQuery<SimpleQuery, JsonSerializable> {
   SimpleQueryQuery();
 
   @override
   final String query =
       'query simple_query { pokemon(name: "Charmander") { number types } }';
+  @override
+  final String operationName = 'simple_query';
 
   @override
   SimpleQuery parse(Map<String, dynamic> json) {
     return SimpleQuery.fromJson(json);
   }
-}
-
-Future<GraphQLResponse<SimpleQuery>> executeSimpleQueryQuery(
-    String graphQLEndpoint,
-    {http.Client client}) async {
-  final httpClient = client ?? http.Client();
-  final dataResponse = await httpClient.post(
-    graphQLEndpoint,
-    body: json.encode({
-      'operationName': 'simple_query',
-      'query':
-          'query simple_query { pokemon(name: "Charmander") { number types } }',
-    }),
-    headers: (client != null)
-        ? null
-        : {
-            'Content-type': 'application/json',
-            'Accept': 'application/json',
-          },
-  );
-
-  final Map<String, dynamic> jsonBody = json.decode(dataResponse.body);
-  final response = GraphQLResponse<SimpleQuery>.fromJson(jsonBody)
-    ..data = SimpleQuery.fromJson(jsonBody['data'] ?? <Map<String, dynamic>>{});
-
-  if (client == null) {
-    httpClient.close();
-  }
-
-  return response;
 }

--- a/example/pokemon/lib/queries/simple_query.query.dart
+++ b/example/pokemon/lib/queries/simple_query.query.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'package:artemis/schema/graphql_query.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:artemis/schema/graphql_error.dart';
 
@@ -31,6 +32,19 @@ class Pokemon {
   Map<String, dynamic> toJson() => _$PokemonToJson(this);
 }
 
+class SimpleQueryQuery extends GraphQLQuery<SimpleQuery> {
+  SimpleQueryQuery();
+
+  @override
+  final String query =
+      'query simple_query { pokemon(name: "Charmander") { number types } }';
+
+  @override
+  SimpleQuery parse(Map<String, dynamic> json) {
+    return SimpleQuery.fromJson(json);
+  }
+}
+
 Future<GraphQLResponse<SimpleQuery>> executeSimpleQueryQuery(
     String graphQLEndpoint,
     {http.Client client}) async {
@@ -42,15 +56,17 @@ Future<GraphQLResponse<SimpleQuery>> executeSimpleQueryQuery(
       'query':
           'query simple_query { pokemon(name: "Charmander") { number types } }',
     }),
-    headers: {
-      'Content-type': 'application/json',
-      'Accept': 'application/json',
-    },
+    headers: (client != null)
+        ? null
+        : {
+            'Content-type': 'application/json',
+            'Accept': 'application/json',
+          },
   );
 
-  final jsonBody = json.decode(dataResponse.body);
+  final Map<String, dynamic> jsonBody = json.decode(dataResponse.body);
   final response = GraphQLResponse<SimpleQuery>.fromJson(jsonBody)
-    ..data = SimpleQuery.fromJson(jsonBody['data'] ?? {});
+    ..data = SimpleQuery.fromJson(jsonBody['data'] ?? <Map<String, dynamic>>{});
 
   if (client == null) {
     httpClient.close();

--- a/example/pokemon/lib/queries/simple_query.query.g.dart
+++ b/example/pokemon/lib/queries/simple_query.query.g.dart
@@ -15,7 +15,7 @@ SimpleQuery _$SimpleQueryFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$SimpleQueryToJson(SimpleQuery instance) =>
     <String, dynamic>{
-      'pokemon': instance.pokemon,
+      'pokemon': instance.pokemon?.toJson(),
     };
 
 Pokemon _$PokemonFromJson(Map<String, dynamic> json) {

--- a/example/pokemon/lib/queries/simple_query.query.g.dart
+++ b/example/pokemon/lib/queries/simple_query.query.g.dart
@@ -14,7 +14,9 @@ SimpleQuery _$SimpleQueryFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$SimpleQueryToJson(SimpleQuery instance) =>
-    <String, dynamic>{'pokemon': instance.pokemon};
+    <String, dynamic>{
+      'pokemon': instance.pokemon,
+    };
 
 Pokemon _$PokemonFromJson(Map<String, dynamic> json) {
   return Pokemon()
@@ -22,5 +24,7 @@ Pokemon _$PokemonFromJson(Map<String, dynamic> json) {
     ..types = (json['types'] as List)?.map((e) => e as String)?.toList();
 }
 
-Map<String, dynamic> _$PokemonToJson(Pokemon instance) =>
-    <String, dynamic>{'number': instance.number, 'types': instance.types};
+Map<String, dynamic> _$PokemonToJson(Pokemon instance) => <String, dynamic>{
+      'number': instance.number,
+      'types': instance.types,
+    };

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -1,0 +1,39 @@
+import 'package:artemis/schema/graphql_error.dart';
+import 'package:artemis/schema/graphql_query.dart';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:json_annotation/json_annotation.dart';
+
+class ArtemisClient {
+  ArtemisClient(this.graphQLEndpoint, {http.Client httpClient}) {
+    this.httpClient = httpClient ?? http.Client();
+  }
+
+  final String graphQLEndpoint;
+  http.Client httpClient;
+
+  Future<GraphQLResponse<T>> execute<T, U extends JsonSerializable>(
+      GraphQLQuery<T, U> query,
+      {http.Client client}) async {
+    final dataResponse = await httpClient.post(
+      graphQLEndpoint,
+      body: json.encode({
+        'operationName': query.operationName,
+        'variables': query.getVariablesMap(),
+        'query': query.query,
+      }),
+      headers: (client != null)
+          ? null
+          : {
+              'Content-type': 'application/json',
+              'Accept': 'application/json',
+            },
+    );
+
+    final Map<String, dynamic> jsonBody = json.decode(dataResponse.body);
+    final response = GraphQLResponse<T>.fromJson(jsonBody)
+      ..data = query.parse(jsonBody['data'] ?? <Map<String, dynamic>>{});
+
+    return response;
+  }
+}

--- a/lib/generator/print_helpers.dart
+++ b/lib/generator/print_helpers.dart
@@ -95,17 +95,19 @@ void printQueryClass(StringBuffer buffer, QueryDefinition definition) {
       .trim();
 
   String variablesDeclaration = '';
-  String constructor = '();';
+  String constructor = '()';
+  String typeDeclaration = '${definition.queryName}, void';
   if (definition.inputs.isNotEmpty) {
     variablesDeclaration = '''  @override
-  final Map<String, dynamic> variables;''';
-    constructor = '''({${definition.queryName}Arguments arguments}) :
-  variables = arguments.toMap();''';
+  final ${definition.queryName}Arguments variables;''';
+    constructor = '''({this.variables})''';
+    typeDeclaration =
+        '${definition.queryName}, ${definition.queryName}Arguments';
   }
 
   final str =
-      '''class ${definition.queryName}Query extends GraphQLQuery<${definition.queryName}> {
-  ${definition.queryName}Query${constructor}
+      '''class ${definition.queryName}Query extends GraphQLQuery<$typeDeclaration> {
+  ${definition.queryName}Query${constructor};
 ${variablesDeclaration}
   @override
   final String query = '${sanitizedQueryStr}';

--- a/lib/generator/print_helpers.dart
+++ b/lib/generator/print_helpers.dart
@@ -71,7 +71,7 @@ void printArgumentsClass(StringBuffer buffer, QueryDefinition definition) {
     argumentConstructor =
         '{' + definition.inputs.map((i) => 'this.${i.name}').join(',\n') + '}';
   }
-  final str = '''@JsonSerializable(explicitToJson: true)
+  buffer.write('''@JsonSerializable(explicitToJson: true)
 class ${definition.queryName}Arguments extends JsonSerializable {
   ${definition.queryName}Arguments(${argumentConstructor});
 
@@ -81,8 +81,7 @@ class ${definition.queryName}Arguments extends JsonSerializable {
       _\$${definition.queryName}ArgumentsFromJson(json);
   Map<String, dynamic> toJson() => _\$${definition.queryName}ArgumentsToJson(this);
 }
-''';
-  buffer.write(str);
+''');
 }
 
 void printQueryClass(StringBuffer buffer, QueryDefinition definition) {
@@ -102,7 +101,7 @@ void printQueryClass(StringBuffer buffer, QueryDefinition definition) {
         '${definition.queryName}, ${definition.queryName}Arguments';
   }
 
-  final str =
+  buffer.write(
       '''class ${definition.queryName}Query extends GraphQLQuery<$typeDeclaration> {
   ${definition.queryName}Query${constructor};
 ${variablesDeclaration}
@@ -116,8 +115,7 @@ ${variablesDeclaration}
     return ${definition.queryName}.fromJson(json);
   }
 }
-''';
-  buffer.write(str);
+''');
 }
 
 void printCustomQuery(StringBuffer buffer, QueryDefinition definition) {

--- a/lib/schema/graphql_query.dart
+++ b/lib/schema/graphql_query.dart
@@ -1,0 +1,8 @@
+abstract class GraphQLQuery<T> {
+  GraphQLQuery({this.variables, this.query});
+
+  final Map<String, dynamic> variables;
+  final String query;
+
+  T parse(Map<String, dynamic> json);
+}

--- a/lib/schema/graphql_query.dart
+++ b/lib/schema/graphql_query.dart
@@ -1,8 +1,15 @@
-abstract class GraphQLQuery<T, U extends Object> {
-  GraphQLQuery({this.variables, this.query});
+import 'package:json_annotation/json_annotation.dart';
+
+abstract class GraphQLQuery<T, U extends JsonSerializable> {
+  GraphQLQuery({this.variables, this.query, this.operationName});
 
   final U variables;
   final String query;
+  final String operationName;
 
   T parse(Map<String, dynamic> json);
+
+  Map<String, dynamic> getVariablesMap() {
+    return (variables != null) ? variables.toJson() : {};
+  }
 }

--- a/lib/schema/graphql_query.dart
+++ b/lib/schema/graphql_query.dart
@@ -1,7 +1,7 @@
-abstract class GraphQLQuery<T> {
+abstract class GraphQLQuery<T, U extends Object> {
   GraphQLQuery({this.variables, this.query});
 
-  final Map<String, dynamic> variables;
+  final U variables;
   final String query;
 
   T parse(Map<String, dynamic> json);

--- a/lib/schema/graphql_query.dart
+++ b/lib/schema/graphql_query.dart
@@ -1,11 +1,11 @@
 import 'package:json_annotation/json_annotation.dart';
 
 abstract class GraphQLQuery<T, U extends JsonSerializable> {
-  GraphQLQuery({this.variables, this.query, this.operationName});
+  GraphQLQuery({this.variables});
 
   final U variables;
-  final String query;
-  final String operationName;
+  final String query = null;
+  final String operationName = null;
 
   T parse(Map<String, dynamic> json);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 0.2.1
+version: 0.3.0
 
 authors:
   - Igor Borges <igor@borges.me>

--- a/test/generator/print_helpers_test.dart
+++ b/test/generator/print_helpers_test.dart
@@ -293,7 +293,7 @@ import 'package:artemis/schema/graphql_query.dart';
 import 'package:artemis/schema/graphql_error.dart';
 
 part 'test_query.query.g.dart';
-class TestQueryQuery extends GraphQLQuery<TestQuery> {
+class TestQueryQuery extends GraphQLQuery<TestQuery, void> {
   TestQueryQuery();
 
   @override
@@ -359,11 +359,10 @@ class TestQueryArguments {
     return {'name': this.name};
   }
 }
-class TestQueryQuery extends GraphQLQuery<TestQuery> {
-  TestQueryQuery({TestQueryArguments arguments}) :
-  variables = arguments.toMap();
+class TestQueryQuery extends GraphQLQuery<TestQuery, TestQueryArguments> {
+  TestQueryQuery({this.variables});
   @override
-  final Map<String, dynamic> variables;
+  final TestQueryArguments variables;
   @override
   final String query = 'query test_query {}';
 
@@ -430,11 +429,10 @@ Future<GraphQLResponse<TestQuery>> executeTestQueryQuery(String graphQLEndpoint,
       printQueryClass(buffer, definition);
 
       expect(buffer.toString(),
-          '''class TestQueryQuery extends GraphQLQuery<TestQuery> {
-  TestQueryQuery({TestQueryArguments arguments}) :
-  variables = arguments.toMap();
+          '''class TestQueryQuery extends GraphQLQuery<TestQuery, TestQueryArguments> {
+  TestQueryQuery({this.variables});
   @override
-  final Map<String, dynamic> variables;
+  final TestQueryArguments variables;
   @override
   final String query = 'query test_query {}';
 

--- a/test/generator/print_helpers_test.dart
+++ b/test/generator/print_helpers_test.dart
@@ -79,7 +79,7 @@ void main() {
 
       expect(buffer.toString(), '''
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class AClass  {
 
   AClass();
@@ -99,7 +99,7 @@ class AClass  {
 
       expect(buffer.toString(), '''
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class AClass extends AnotherClass {
 
   AClass();
@@ -125,7 +125,7 @@ class AClass extends AnotherClass {
 
       expect(buffer.toString(), '''
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class AClass  {
 
   AClass();
@@ -165,7 +165,7 @@ class AClass  {
 
       expect(buffer.toString(), '''
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class AClass  {
   Type name;
   AnotherType anotherName;
@@ -193,7 +193,7 @@ class AClass  {
 
       expect(buffer.toString(), '''
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class AClass  {
   Type name;
   @Hey()
@@ -293,41 +293,18 @@ import 'package:artemis/schema/graphql_query.dart';
 import 'package:artemis/schema/graphql_error.dart';
 
 part 'test_query.query.g.dart';
-class TestQueryQuery extends GraphQLQuery<TestQuery, void> {
+class TestQueryQuery extends GraphQLQuery<TestQuery, JsonSerializable> {
   TestQueryQuery();
 
   @override
   final String query = 'query test_query {}';
+  @override
+  final String operationName = 'test_query';
 
   @override
   TestQuery parse(Map<String, dynamic> json) {
     return TestQuery.fromJson(json);
   }
-}
-Future<GraphQLResponse<TestQuery>> executeTestQueryQuery(String graphQLEndpoint,  {http.Client client}) async {
-  final httpClient = client ?? http.Client();
-  final dataResponse = await httpClient.post(graphQLEndpoint,
-    body: json.encode({
-      'operationName': 'test_query',
-      'query': 'query test_query {}',
-    }),
-    headers: (client != null)
-        ? null
-        : {
-            'Content-type': 'application/json',
-            'Accept': 'application/json',
-          },
-  );
-
-  final Map<String, dynamic> jsonBody = json.decode(dataResponse.body);
-  final response = GraphQLResponse<TestQuery>.fromJson(jsonBody)
-    ..data = TestQuery.fromJson(jsonBody['data'] ?? <Map<String, dynamic>>{});
-
-  if (client == null) {
-    httpClient.close();
-  }
-
-  return response;
 }
 ''');
     });
@@ -350,14 +327,15 @@ import 'package:artemis/schema/graphql_query.dart';
 import 'package:artemis/schema/graphql_error.dart';
 
 part 'test_query.query.g.dart';
-class TestQueryArguments {
+@JsonSerializable(explicitToJson: true)
+class TestQueryArguments extends JsonSerializable {
   TestQueryArguments({this.name});
 
   final Type name;
   
-  Map<String, dynamic> toMap() {
-    return {'name': this.name};
-  }
+  factory TestQueryArguments.fromJson(Map<String, dynamic> json) =>
+      _\$TestQueryArgumentsFromJson(json);
+  Map<String, dynamic> toJson() => _\$TestQueryArgumentsToJson(this);
 }
 class TestQueryQuery extends GraphQLQuery<TestQuery, TestQueryArguments> {
   TestQueryQuery({this.variables});
@@ -365,37 +343,13 @@ class TestQueryQuery extends GraphQLQuery<TestQuery, TestQueryArguments> {
   final TestQueryArguments variables;
   @override
   final String query = 'query test_query {}';
+  @override
+  final String operationName = 'test_query';
 
   @override
   TestQuery parse(Map<String, dynamic> json) {
     return TestQuery.fromJson(json);
   }
-}
-Future<GraphQLResponse<TestQuery>> executeTestQueryQuery(String graphQLEndpoint, Type name, {http.Client client}) async {
-  final httpClient = client ?? http.Client();
-  final dataResponse = await httpClient.post(graphQLEndpoint,
-    body: json.encode({
-      'operationName': 'test_query',
-      'query': 'query test_query {}',
-      'variables': {'name': name},
-    }),
-    headers: (client != null)
-        ? null
-        : {
-            'Content-type': 'application/json',
-            'Accept': 'application/json',
-          },
-  );
-
-  final Map<String, dynamic> jsonBody = json.decode(dataResponse.body);
-  final response = GraphQLResponse<TestQuery>.fromJson(jsonBody)
-    ..data = TestQuery.fromJson(jsonBody['data'] ?? <Map<String, dynamic>>{});
-
-  if (client == null) {
-    httpClient.close();
-  }
-
-  return response;
 }
 ''');
     });
@@ -408,14 +362,15 @@ Future<GraphQLResponse<TestQuery>> executeTestQueryQuery(String graphQLEndpoint,
 
       printArgumentsClass(buffer, definition);
 
-      expect(buffer.toString(), '''class TestQueryArguments {
+      expect(buffer.toString(), '''@JsonSerializable(explicitToJson: true)
+class TestQueryArguments extends JsonSerializable {
   TestQueryArguments({this.name});
 
   final Type name;
   
-  Map<String, dynamic> toMap() {
-    return {'name': this.name};
-  }
+  factory TestQueryArguments.fromJson(Map<String, dynamic> json) =>
+      _\$TestQueryArgumentsFromJson(json);
+  Map<String, dynamic> toJson() => _\$TestQueryArgumentsToJson(this);
 }
 ''');
     });
@@ -435,6 +390,8 @@ Future<GraphQLResponse<TestQuery>> executeTestQueryQuery(String graphQLEndpoint,
   final TestQueryArguments variables;
   @override
   final String query = 'query test_query {}';
+  @override
+  final String operationName = 'test_query';
 
   @override
   TestQuery parse(Map<String, dynamic> json) {
@@ -464,7 +421,7 @@ enum Enum {
   Value,
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class AClass  {
 
   AClass();

--- a/test/generator/print_helpers_test.dart
+++ b/test/generator/print_helpers_test.dart
@@ -289,9 +289,21 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:json_annotation/json_annotation.dart';
+import 'package:artemis/schema/graphql_query.dart';
 import 'package:artemis/schema/graphql_error.dart';
 
 part 'test_query.query.g.dart';
+class TestQueryQuery extends GraphQLQuery<TestQuery> {
+  TestQueryQuery();
+
+  @override
+  final String query = 'query test_query {}';
+
+  @override
+  TestQuery parse(Map<String, dynamic> json) {
+    return TestQuery.fromJson(json);
+  }
+}
 Future<GraphQLResponse<TestQuery>> executeTestQueryQuery(String graphQLEndpoint,  {http.Client client}) async {
   final httpClient = client ?? http.Client();
   final dataResponse = await httpClient.post(graphQLEndpoint,
@@ -334,9 +346,32 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:json_annotation/json_annotation.dart';
+import 'package:artemis/schema/graphql_query.dart';
 import 'package:artemis/schema/graphql_error.dart';
 
 part 'test_query.query.g.dart';
+class TestQueryArguments {
+  TestQueryArguments({this.name});
+
+  final Type name;
+  
+  Map<String, dynamic> toMap() {
+    return {'name': this.name};
+  }
+}
+class TestQueryQuery extends GraphQLQuery<TestQuery> {
+  TestQueryQuery({TestQueryArguments arguments}) :
+  variables = arguments.toMap();
+  @override
+  final Map<String, dynamic> variables;
+  @override
+  final String query = 'query test_query {}';
+
+  @override
+  TestQuery parse(Map<String, dynamic> json) {
+    return TestQuery.fromJson(json);
+  }
+}
 Future<GraphQLResponse<TestQuery>> executeTestQueryQuery(String graphQLEndpoint, Type name, {http.Client client}) async {
   final httpClient = client ?? http.Client();
   final dataResponse = await httpClient.post(graphQLEndpoint,
@@ -362,6 +397,51 @@ Future<GraphQLResponse<TestQuery>> executeTestQueryQuery(String graphQLEndpoint,
   }
 
   return response;
+}
+''');
+    });
+
+    test('Will generate an Arguments class', () {
+      final buffer = StringBuffer();
+      final definition = QueryDefinition(
+          'TestQuery', 'query test_query {}', 'test_query',
+          generateHelpers: true, inputs: [QueryInput('Type', 'name')]);
+
+      printArgumentsClass(buffer, definition);
+
+      expect(buffer.toString(), '''class TestQueryArguments {
+  TestQueryArguments({this.name});
+
+  final Type name;
+  
+  Map<String, dynamic> toMap() {
+    return {'name': this.name};
+  }
+}
+''');
+    });
+
+    test('Will generate a Query Class', () {
+      final buffer = StringBuffer();
+      final definition = QueryDefinition(
+          'TestQuery', 'query test_query {}', 'test_query',
+          generateHelpers: true, inputs: [QueryInput('Type', 'name')]);
+
+      printQueryClass(buffer, definition);
+
+      expect(buffer.toString(),
+          '''class TestQueryQuery extends GraphQLQuery<TestQuery> {
+  TestQueryQuery({TestQueryArguments arguments}) :
+  variables = arguments.toMap();
+  @override
+  final Map<String, dynamic> variables;
+  @override
+  final String query = 'query test_query {}';
+
+  @override
+  TestQuery parse(Map<String, dynamic> json) {
+    return TestQuery.fromJson(json);
+  }
 }
 ''');
     });

--- a/test/query_generator/query_generator_test.dart
+++ b/test/query_generator/query_generator_test.dart
@@ -73,7 +73,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'some_query.query.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SomeQuery {
   String s;
   int i;
@@ -186,7 +186,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'some_query.query.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SomeQuery {
   String s;
   SomeObject o;
@@ -198,7 +198,7 @@ class SomeQuery {
   Map<String, dynamic> toJson() => _\$SomeQueryToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SomeObject {
   String st;
   List<AnotherObject> ob;
@@ -210,7 +210,7 @@ class SomeObject {
   Map<String, dynamic> toJson() => _\$SomeObjectToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class AnotherObject {
   String str;
 
@@ -279,7 +279,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'some_query.query.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SomeQuery {
   String firstName;
   String lastName;
@@ -388,7 +388,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'some_query.query.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SomeQuery {
   String s;
   SomeObject o;
@@ -401,7 +401,7 @@ class SomeQuery {
   Map<String, dynamic> toJson() => _\$SomeQueryToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SomeObject {
   String st;
 
@@ -412,7 +412,7 @@ class SomeObject {
   Map<String, dynamic> toJson() => _\$SomeObjectToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class AnotherObject {
   String str;
 
@@ -518,11 +518,12 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:json_annotation/json_annotation.dart';
+import 'package:artemis/schema/graphql_query.dart';
 import 'package:artemis/schema/graphql_error.dart';
 
 part 'some_query.query.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SomeQuery {
   String s;
   SomeObject o;
@@ -535,7 +536,7 @@ class SomeQuery {
   Map<String, dynamic> toJson() => _\$SomeQueryToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SomeObject {
   String st;
 
@@ -546,7 +547,7 @@ class SomeObject {
   Map<String, dynamic> toJson() => _\$SomeObjectToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class AnotherObject {
   String str;
 
@@ -557,32 +558,19 @@ class AnotherObject {
   Map<String, dynamic> toJson() => _\$AnotherObjectToJson(this);
 }
 
-Future<GraphQLResponse<SomeQuery>> executeSomeQueryQuery(String graphQLEndpoint,
-    {http.Client client}) async {
-  final httpClient = client ?? http.Client();
-  final dataResponse = await httpClient.post(
-    graphQLEndpoint,
-    body: json.encode({
-      'operationName': 'some_query',
-      'query': 'query some_query { s o { st } anotherObject: ob { str } }',
-    }),
-    headers: (client != null)
-        ? null
-        : {
-            'Content-type': 'application/json',
-            'Accept': 'application/json',
-          },
-  );
+class SomeQueryQuery extends GraphQLQuery<SomeQuery, JsonSerializable> {
+  SomeQueryQuery();
 
-  final Map<String, dynamic> jsonBody = json.decode(dataResponse.body);
-  final response = GraphQLResponse<SomeQuery>.fromJson(jsonBody)
-    ..data = SomeQuery.fromJson(jsonBody['data'] ?? <Map<String, dynamic>>{});
+  @override
+  final String query =
+      'query some_query { s o { st } anotherObject: ob { str } }';
+  @override
+  final String operationName = 'some_query';
 
-  if (client == null) {
-    httpClient.close();
+  @override
+  SomeQuery parse(Map<String, dynamic> json) {
+    return SomeQuery.fromJson(json);
   }
-
-  return response;
 }
 ''',
       });


### PR DESCRIPTION
This PR adds a new feature to Artemis, making it able to generate two new classes:

- `Argument` class, that contains the structure of all the arguments required by a query.
- `Query` class, that act as a Data class for the query, when instantiating it, passing an `Argument` object if necessary. It includes the query string and the parser function for the data returned.

This feature is especially useful for making a lot easier to integrate Artemis with other existing network solutions for GraphQL, thus, not coupling its main feature of GraphQL<-> Dart conversion with the request/response/caching/etc... layers of the GraphQL usual request flow.

Tests were written and updated, and also the examples folder updated to include those new features.