### PR TITLE
Defaults response to charset utf-8

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -40,7 +40,8 @@ class ArtemisClient {
       }),
     );
 
-    final Map<String, dynamic> jsonBody = json.decode(utf8.decode(dataResponse.bodyBytes));
+    final Map<String, dynamic> jsonBody = 
+      json.decode(utf8.decode(dataResponse.bodyBytes));
     final response = GraphQLResponse<T>.fromJson(jsonBody)
       ..data = query.parse(jsonBody['data'] ?? {});
 

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -41,7 +41,7 @@ class ArtemisClient {
     );
 
     final Map<String, dynamic> jsonBody = 
-      json.decode(utf8.decode(dataResponse.bodyBytes));
+        json.decode(utf8.decode(dataResponse.bodyBytes));
     final response = GraphQLResponse<T>.fromJson(jsonBody)
       ..data = query.parse(jsonBody['data'] ?? {});
 

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -40,7 +40,7 @@ class ArtemisClient {
       }),
     );
 
-    final Map<String, dynamic> jsonBody = json.decode(dataResponse.body);
+    final Map<String, dynamic> jsonBody = json.decode(utf8.decode(dataResponse.bodyBytes));
     final response = GraphQLResponse<T>.fromJson(jsonBody)
       ..data = query.parse(jsonBody['data'] ?? {});
 

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -40,7 +40,7 @@ class ArtemisClient {
       }),
     );
 
-    final Map<String, dynamic> jsonBody = 
+    final Map<String, dynamic> jsonBody =
         json.decode(utf8.decode(dataResponse.bodyBytes));
     final response = GraphQLResponse<T>.fromJson(jsonBody)
       ..data = query.parse(jsonBody['data'] ?? {});


### PR DESCRIPTION
Even if the server is responding with header `Content-Type`: `application/json; charset=utf-8`, `response.body` is converting to iso-8859, breaking encoding in ios.
By setting the default json charset as utf-8, you prevent it from happening.