### PR TITLE
Allow scalar mappings to include imports for types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.4.0
+- Allow scalar mappings to include imports for types
+
 ## 0.3.2
 - Decode HTTP response as UTF-8 on execute helper.
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,23 @@ targets:
             dart_type: DateTime
 ```
 
+If your custom scalar needs to import Dart libraries, you can provide it in the config as well:
+
+```yaml
+targets:
+  $default:
+    builders:
+      artemis:
+        options:
+          custom_parser_import: 'package:graphbrainz_example/coercers.dart'
+          scalar_mapping:
+          - graphql_type: BigDecimal
+            dart_type:
+              name: Decimal
+              imports:
+              - 'package:decimal/decimal.dart'
+```
+
 Each `ScalarMap` is configured this way:
 
 | Option | Default value | Description |

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -72,6 +72,9 @@ QueryDefinition generateQuery(
     });
   }
 
+  final List<String> customImports =
+      _extractCustomImports(schema.types, options);
+
   final classes = _extractClasses(operation.selectionSet, fragments, schema,
       queryName, parentType, options, schemaMap);
 
@@ -84,8 +87,20 @@ QueryDefinition generateQuery(
     inputs: inputs,
     generateHelpers: options.generateHelpers,
     customParserImport: options.customParserImport,
+    customImports: customImports,
   );
 }
+
+List<String> _extractCustomImports(
+  List<GraphQLType> types,
+  GeneratorOptions options,
+) =>
+    types
+        .map((GraphQLType type) =>
+            gql.getSingleScalarMap(options, type).dartType.imports)
+        .expand((i) => i)
+        .toSet()
+        .toList();
 
 ClassProperty _createClassProperty(
     String fieldName,

--- a/lib/generator/data.dart
+++ b/lib/generator/data.dart
@@ -114,6 +114,7 @@ class QueryDefinition {
   final Iterable<QueryInput> inputs;
   final String customParserImport;
   final bool generateHelpers;
+  final Iterable<String> customImports;
 
   QueryDefinition(
     this.queryName,
@@ -123,6 +124,7 @@ class QueryDefinition {
     this.inputs = const [],
     this.customParserImport,
     this.generateHelpers = false,
+    this.customImports = const [],
   })  : assert(queryName != null && queryName.isNotEmpty,
             'Query name must not be null or empty.'),
         assert(query != null && query.isNotEmpty,
@@ -138,7 +140,8 @@ class QueryDefinition {
       _eq(o.classes, classes) &&
       _eq(o.inputs, inputs) &&
       o.customParserImport == customParserImport &&
-      o.generateHelpers == generateHelpers;
+      o.generateHelpers == generateHelpers &&
+      _eq(o.customImports, customImports);
   int get hashCode =>
       queryName.hashCode ^
       query.hashCode ^
@@ -146,5 +149,6 @@ class QueryDefinition {
       classes.hashCode ^
       inputs.hashCode ^
       customParserImport.hashCode ^
-      generateHelpers.hashCode;
+      generateHelpers.hashCode ^
+      customImports.hashCode;
 }

--- a/lib/generator/graphql_helpers.dart
+++ b/lib/generator/graphql_helpers.dart
@@ -25,7 +25,7 @@ String buildTypeString(GraphQLType type, GeneratorOptions options,
           dartType: dartType, replaceLeafWith: replaceLeafWith);
     case GraphQLTypeKind.SCALAR:
       final scalar = getSingleScalarMap(options, type);
-      return dartType ? scalar.dartType : scalar.graphQLType;
+      return dartType ? scalar.dartType.name : scalar.graphQLType;
     default:
       if (replaceLeafWith != null) return replaceLeafWith;
       return type.name;
@@ -33,17 +33,21 @@ String buildTypeString(GraphQLType type, GeneratorOptions options,
 }
 
 List<ScalarMap> _defaultScalarMapping = [
-  ScalarMap(graphQLType: 'Boolean', dartType: 'bool'),
-  ScalarMap(graphQLType: 'Float', dartType: 'double'),
-  ScalarMap(graphQLType: 'ID', dartType: 'String'),
-  ScalarMap(graphQLType: 'Int', dartType: 'int'),
-  ScalarMap(graphQLType: 'String', dartType: 'String'),
+  ScalarMap(graphQLType: 'Boolean', dartType: const DartType(name: 'bool')),
+  ScalarMap(graphQLType: 'Float', dartType: const DartType(name: 'double')),
+  ScalarMap(graphQLType: 'ID', dartType: const DartType(name: 'String')),
+  ScalarMap(graphQLType: 'Int', dartType: const DartType(name: 'int')),
+  ScalarMap(graphQLType: 'String', dartType: const DartType(name: 'String')),
 ];
 
 ScalarMap getSingleScalarMap(GeneratorOptions options, GraphQLType type) =>
-    options.scalarMapping.followedBy(_defaultScalarMapping).firstWhere(
-        (m) => m.graphQLType == type.name,
-        orElse: () => ScalarMap(graphQLType: type.name, dartType: type.name));
+    options.scalarMapping
+        .followedBy(_defaultScalarMapping)
+        .firstWhere((m) => m.graphQLType == type.name,
+            orElse: () => ScalarMap(
+                  graphQLType: type.name,
+                  dartType: DartType(name: type.name),
+                ));
 
 GraphQLSchema schemaFromJsonString(String jsonS) =>
     GraphQLSchema.fromJson(json.decode(jsonS));

--- a/lib/generator/print_helpers.dart
+++ b/lib/generator/print_helpers.dart
@@ -130,6 +130,10 @@ import 'package:http/http.dart' as http;''');
   if (definition.customParserImport != null) {
     buffer.writeln('import \'${definition.customParserImport}\';');
   }
+
+  definition.customImports
+      .forEach((customImport) => buffer.writeln('import \'$customImport\';'));
+
   if (definition.generateHelpers) {
     buffer.writeln('import \'package:artemis/artemis.dart\';');
   }

--- a/lib/schema/options.dart
+++ b/lib/schema/options.dart
@@ -28,11 +28,36 @@ class GeneratorOptions {
   Map<String, dynamic> toJson() => _$GeneratorOptionsToJson(this);
 }
 
+@JsonSerializable()
+class DartType {
+  final String name;
+
+  @JsonKey(defaultValue: <String>[])
+  final List<String> imports;
+
+  const DartType({
+    this.name,
+    this.imports = const [],
+  });
+
+  factory DartType.fromJson(dynamic json) {
+    if (json is String) {
+      return DartType(name: json);
+    } else if (json is Map<String, dynamic>) {
+      return _$DartTypeFromJson(json);
+    } else {
+      throw 'Invalid json: $json';
+    }
+  }
+
+  Map<String, dynamic> toJson() => _$DartTypeToJson(this);
+}
+
 @JsonSerializable(fieldRename: FieldRename.snake)
 class ScalarMap {
   @JsonKey(name: 'graphql_type')
   final String graphQLType;
-  final String dartType;
+  final DartType dartType;
   @JsonKey(defaultValue: false)
   final bool useCustomParser;
 

--- a/lib/schema/options.g2.dart
+++ b/lib/schema/options.g2.dart
@@ -36,10 +36,22 @@ Map<String, dynamic> _$GeneratorOptionsToJson(GeneratorOptions instance) =>
       'schema_mapping': instance.schemaMapping
     };
 
+DartType _$DartTypeFromJson(Map<String, dynamic> json) {
+  return DartType(
+      name: json['name'] as String,
+      imports:
+          (json['imports'] as List)?.map((e) => e as String)?.toList() ?? []);
+}
+
+Map<String, dynamic> _$DartTypeToJson(DartType instance) =>
+    <String, dynamic>{'name': instance.name, 'imports': instance.imports};
+
 ScalarMap _$ScalarMapFromJson(Map<String, dynamic> json) {
   return ScalarMap(
       graphQLType: json['graphql_type'] as String,
-      dartType: json['dart_type'] as String,
+      dartType: json['dart_type'] == null
+          ? null
+          : DartType.fromJson(json['dart_type']),
       useCustomParser: json['use_custom_parser'] as bool ?? false);
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 0.3.2
+version: 0.4.0
 
 authors:
   - Igor Borges <igor@borges.me>


### PR DESCRIPTION
Until now, generated code did not include imports for types mapped to scalars and so it would fail to build.

This allows us to provide a new form of `dart_type` definition: with the type name and a list of imports it might need.

For example:

```yaml
scalar_mappings:
  - graphql_type: BigDecimal
    dart_type:
      name: Decimal
      imports:
        - package:decimal/decimal.dart
```

The old form, a string with the type name, is still supported for backward compatibility.

Closes #5.