### PR TITLE
Make all generated classes implement == and hashCode using Equatable

### DIFF
--- a/example/graphbrainz/lib/main.dart
+++ b/example/graphbrainz/lib/main.dart
@@ -7,7 +7,10 @@ Future<void> main() async {
   final client = ArtemisClient(graphQLEndpoint);
 
   final query = EdSheeranQuery();
+  final query2 = EdSheeranQuery();
   final response = await client.execute(query);
+
+  print('Equality works: ${query == query2}');
 
   if (response.hasErrors) {
     return print('Error: ${response.errors.map((e) => e.message).toList()}');

--- a/example/graphbrainz/lib/queries/ed_sheeran.query.dart
+++ b/example/graphbrainz/lib/queries/ed_sheeran.query.dart
@@ -2,11 +2,12 @@
 
 import 'package:artemis/artemis.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
 import 'package:graphbrainz_example/coercers.dart';
 part 'ed_sheeran.query.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class EdSheeran {
+class EdSheeran with EquatableMixin {
   EdSheeran();
 
   factory EdSheeran.fromJson(Map<String, dynamic> json) =>
@@ -14,11 +15,13 @@ class EdSheeran {
 
   Node node;
 
+  @override
+  List<Object> get props => [node];
   Map<String, dynamic> toJson() => _$EdSheeranToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)
-class Node {
+class Node with EquatableMixin {
   Node();
 
   factory Node.fromJson(Map<String, dynamic> json) {
@@ -35,6 +38,8 @@ class Node {
   @JsonKey(name: '__typename')
   String resolveType;
 
+  @override
+  List<Object> get props => [id, resolveType];
   Map<String, dynamic> toJson() {
     switch (resolveType) {
       case 'Artist':
@@ -46,7 +51,7 @@ class Node {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Artist implements Node, Entity {
+class Artist with EquatableMixin implements Node, Entity {
   Artist();
 
   factory Artist.fromJson(Map<String, dynamic> json) => _$ArtistFromJson(json);
@@ -66,11 +71,13 @@ class Artist implements Node, Entity {
   @override
   String id;
 
+  @override
+  List<Object> get props => [mbid, name, lifeSpan, spotify, resolveType, id];
   Map<String, dynamic> toJson() => _$ArtistToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)
-class LifeSpan {
+class LifeSpan with EquatableMixin {
   LifeSpan();
 
   factory LifeSpan.fromJson(Map<String, dynamic> json) =>
@@ -81,11 +88,13 @@ class LifeSpan {
       toJson: fromDartDateTimeToGraphQLDate)
   DateTime begin;
 
+  @override
+  List<Object> get props => [begin];
   Map<String, dynamic> toJson() => _$LifeSpanToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)
-class SpotifyArtist {
+class SpotifyArtist with EquatableMixin {
   SpotifyArtist();
 
   factory SpotifyArtist.fromJson(Map<String, dynamic> json) =>
@@ -93,11 +102,13 @@ class SpotifyArtist {
 
   String href;
 
+  @override
+  List<Object> get props => [href];
   Map<String, dynamic> toJson() => _$SpotifyArtistToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)
-class Entity {
+class Entity with EquatableMixin {
   Entity();
 
   factory Entity.fromJson(Map<String, dynamic> json) => _$EntityFromJson(json);
@@ -107,6 +118,8 @@ class Entity {
   @JsonKey(name: '__typename')
   String resolveType;
 
+  @override
+  List<Object> get props => [mbid, resolveType];
   Map<String, dynamic> toJson() => _$EntityToJson(this);
 }
 
@@ -120,6 +133,8 @@ class EdSheeranQuery extends GraphQLQuery<EdSheeran, JsonSerializable> {
   @override
   final String operationName = 'ed_sheeran';
 
+  @override
+  List<Object> get props => [query, operationName];
   @override
   EdSheeran parse(Map<String, dynamic> json) => EdSheeran.fromJson(json);
 }

--- a/example/graphbrainz/pubspec.lock
+++ b/example/graphbrainz/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.6.1"
   async:
     dependency: transitive
     description:
@@ -148,6 +148,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.10"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.1"
   fixnum:
     dependency: transitive
     description:

--- a/example/pokemon/lib/main.dart
+++ b/example/pokemon/lib/main.dart
@@ -10,6 +10,10 @@ Future<void> main() async {
   final simpleQuery = SimpleQueryQuery();
   final bigQuery = BigQueryQuery(variables: BigQueryArguments(quantity: 5));
 
+  final bigQuery2 = BigQueryQuery(variables: BigQueryArguments(quantity: 5));
+
+  print('Equality works: ${bigQuery == bigQuery2}');
+
   final simpleQueryResponse = await client.execute(simpleQuery);
   final bigQueryResponse = await client.execute(bigQuery);
 

--- a/example/pokemon/lib/queries/big_query.query.dart
+++ b/example/pokemon/lib/queries/big_query.query.dart
@@ -1,11 +1,12 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 import 'package:artemis/artemis.dart';
+import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'big_query.query.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class BigQuery {
+class BigQuery with EquatableMixin {
   BigQuery();
 
   factory BigQuery.fromJson(Map<String, dynamic> json) =>
@@ -15,11 +16,13 @@ class BigQuery {
 
   List<Pokemon> pokemons;
 
+  @override
+  List<Object> get props => [charmander, pokemons];
   Map<String, dynamic> toJson() => _$BigQueryToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)
-class Charmander {
+class Charmander with EquatableMixin {
   Charmander();
 
   factory Charmander.fromJson(Map<String, dynamic> json) =>
@@ -29,11 +32,13 @@ class Charmander {
 
   List<String> types;
 
+  @override
+  List<Object> get props => [number, types];
   Map<String, dynamic> toJson() => _$CharmanderToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)
-class Pokemon {
+class Pokemon with EquatableMixin {
   Pokemon();
 
   factory Pokemon.fromJson(Map<String, dynamic> json) =>
@@ -47,11 +52,13 @@ class Pokemon {
 
   List<Evolutions> evolutions;
 
+  @override
+  List<Object> get props => [number, name, types, evolutions];
   Map<String, dynamic> toJson() => _$PokemonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)
-class Evolutions {
+class Evolutions with EquatableMixin {
   Evolutions();
 
   factory Evolutions.fromJson(Map<String, dynamic> json) =>
@@ -61,11 +68,13 @@ class Evolutions {
 
   String name;
 
+  @override
+  List<Object> get props => [number, name];
   Map<String, dynamic> toJson() => _$EvolutionsToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)
-class BigQueryArguments extends JsonSerializable {
+class BigQueryArguments extends JsonSerializable with EquatableMixin {
   BigQueryArguments({this.quantity});
 
   factory BigQueryArguments.fromJson(Map<String, dynamic> json) =>
@@ -73,6 +82,8 @@ class BigQueryArguments extends JsonSerializable {
 
   final int quantity;
 
+  @override
+  List<Object> get props => [quantity];
   Map<String, dynamic> toJson() => _$BigQueryArgumentsToJson(this);
 }
 
@@ -89,6 +100,8 @@ class BigQueryQuery extends GraphQLQuery<BigQuery, BigQueryArguments> {
   @override
   final BigQueryArguments variables;
 
+  @override
+  List<Object> get props => [query, operationName, variables];
   @override
   BigQuery parse(Map<String, dynamic> json) => BigQuery.fromJson(json);
 }

--- a/example/pokemon/lib/queries/simple_query.query.dart
+++ b/example/pokemon/lib/queries/simple_query.query.dart
@@ -1,11 +1,12 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 import 'package:artemis/artemis.dart';
+import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'simple_query.query.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SimpleQuery {
+class SimpleQuery with EquatableMixin {
   SimpleQuery();
 
   factory SimpleQuery.fromJson(Map<String, dynamic> json) =>
@@ -13,11 +14,13 @@ class SimpleQuery {
 
   Pokemon pokemon;
 
+  @override
+  List<Object> get props => [pokemon];
   Map<String, dynamic> toJson() => _$SimpleQueryToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)
-class Pokemon {
+class Pokemon with EquatableMixin {
   Pokemon();
 
   factory Pokemon.fromJson(Map<String, dynamic> json) =>
@@ -27,6 +30,8 @@ class Pokemon {
 
   List<String> types;
 
+  @override
+  List<Object> get props => [number, types];
   Map<String, dynamic> toJson() => _$PokemonToJson(this);
 }
 
@@ -40,6 +45,8 @@ class SimpleQueryQuery extends GraphQLQuery<SimpleQuery, JsonSerializable> {
   @override
   final String operationName = 'simple_query';
 
+  @override
+  List<Object> get props => [query, operationName];
   @override
   SimpleQuery parse(Map<String, dynamic> json) => SimpleQuery.fromJson(json);
 }

--- a/example/pokemon/pubspec.lock
+++ b/example/pokemon/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.6.1"
   async:
     dependency: transitive
     description:
@@ -148,6 +148,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.10"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.1"
   fixnum:
     dependency: transitive
     description:

--- a/lib/generator/data.dart
+++ b/lib/generator/data.dart
@@ -1,8 +1,6 @@
-import 'package:collection/collection.dart';
+import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
 import '../schema/graphql.dart';
-
-final Function _eq = const ListEquality().equals;
 
 /// Callback fired when the generator processes a [QueryDefinition].
 typedef void OnBuildQuery(QueryDefinition definition);
@@ -15,7 +13,7 @@ typedef void OnNewClassFoundCallback(
 );
 
 /// Define a property (field) from a class.
-class ClassProperty {
+class ClassProperty extends Equatable {
   /// The property type.
   final String type;
 
@@ -38,18 +36,11 @@ class ClassProperty {
           override: override ?? this.override,
           annotation: annotation ?? this.annotation);
 
-  bool operator ==(dynamic o) =>
-      o is ClassProperty &&
-      o.type == type &&
-      o.name == name &&
-      o.override == override &&
-      o.annotation == annotation;
-  int get hashCode =>
-      type.hashCode ^ name.hashCode ^ override.hashCode ^ annotation.hashCode;
+  List get props => [type, name, override, annotation];
 }
 
 /// Define a query/mutation input parameter.
-class QueryInput {
+class QueryInput extends Equatable {
   /// The input type.
   final String type;
 
@@ -63,13 +54,12 @@ class QueryInput {
         assert(
             name != null && name.isNotEmpty, 'Name can\'t be null nor empty.');
 
-  bool operator ==(dynamic o) =>
-      o is QueryInput && o.type == type && o.name == name;
-  int get hashCode => type.hashCode ^ name.hashCode;
+  @override
+  List get props => [type, name];
 }
 
 /// Abstract definition of an entity.
-abstract class Definition {
+abstract class Definition extends Equatable {
   /// The definition name.
   final String name;
 
@@ -78,8 +68,8 @@ abstract class Definition {
       : assert(
             name != null && name.isNotEmpty, 'Name can\'t be null nor empty.');
 
-  bool operator ==(dynamic o) => o is Definition && o.name == name;
-  int get hashCode => name.hashCode;
+  @override
+  List get props => [name];
 }
 
 /// Define a Dart class parsed from GraphQL schema.
@@ -110,21 +100,15 @@ class ClassDefinition extends Definition {
     this.resolveTypeField = '__resolveType',
   }) : super(name);
 
-  bool operator ==(dynamic o) =>
-      o is ClassDefinition &&
-      o.name == name &&
-      _eq(o.properties, properties) &&
-      o.extension == extension &&
-      _eq(o.implementations, implementations) &&
-      _eq(o.factoryPossibilities, factoryPossibilities) &&
-      o.resolveTypeField == resolveTypeField;
-  int get hashCode =>
-      name.hashCode ^
-      properties.hashCode ^
-      extension.hashCode ^
-      implementations.hashCode ^
-      factoryPossibilities.hashCode ^
-      resolveTypeField.hashCode;
+  @override
+  List get props => [
+        name,
+        properties,
+        extension,
+        implementations,
+        factoryPossibilities,
+        resolveTypeField
+      ];
 }
 
 /// Define a Dart enum parsed from GraphQL schema.
@@ -140,13 +124,12 @@ class EnumDefinition extends Definition {
             'An enum must have at least one possible value.'),
         super(name);
 
-  bool operator ==(dynamic o) =>
-      o is EnumDefinition && o.name == name && _eq(o.values, values);
-  int get hashCode => name.hashCode ^ values.hashCode;
+  @override
+  List get props => [name, values];
 }
 
 /// Define a GraphQL query.
-class QueryDefinition {
+class QueryDefinition extends Equatable {
   /// The query name.
   final String queryName;
 
@@ -188,23 +171,15 @@ class QueryDefinition {
         assert(basename != null && basename.isNotEmpty,
             'Basename must not be null or empty.');
 
-  bool operator ==(dynamic o) =>
-      o is QueryDefinition &&
-      o.queryName == queryName &&
-      o.query == query &&
-      o.basename == basename &&
-      _eq(o.classes, classes) &&
-      _eq(o.inputs, inputs) &&
-      o.customParserImport == customParserImport &&
-      o.generateHelpers == generateHelpers &&
-      _eq(o.customImports, customImports);
-  int get hashCode =>
-      queryName.hashCode ^
-      query.hashCode ^
-      basename.hashCode ^
-      classes.hashCode ^
-      inputs.hashCode ^
-      customParserImport.hashCode ^
-      generateHelpers.hashCode ^
-      customImports.hashCode;
+  @override
+  List get props => [
+        queryName,
+        query,
+        basename,
+        classes,
+        inputs,
+        customImports,
+        generateHelpers,
+        customParserImport
+      ];
 }

--- a/lib/schema/graphql_query.dart
+++ b/lib/schema/graphql_query.dart
@@ -1,8 +1,9 @@
+import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 /// A GraphQL query abstraction. This class should be extended automatically
 /// by Artemis and used with [ArtemisClient].
-abstract class GraphQLQuery<T, U extends JsonSerializable> {
+abstract class GraphQLQuery<T, U extends JsonSerializable> extends Equatable {
   /// Instantiates a query or mutation.
   GraphQLQuery({this.variables});
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   source_gen: ^0.9.4+2
   path: ^1.6.2
   gql: ^0.1.0
+  equatable: ^0.5.1
   source_span: ^1.5.5
   recase: ^2.0.1
   glob: ^1.1.7

--- a/test/generator/print_helpers_test.dart
+++ b/test/generator/print_helpers_test.dart
@@ -69,11 +69,13 @@ void main() {
       final str = specToString(classDefinitionToSpec(definition));
 
       expect(str, '''@JsonSerializable(explicitToJson: true)
-class AClass {
+class AClass with EquatableMixin {
   AClass();
 
   factory AClass.fromJson(Map<String, dynamic> json) => _\$AClassFromJson(json);
 
+  @override
+  List<Object> get props => [];
   Map<String, dynamic> toJson() => _\$AClassToJson(this);
 }
 ''');
@@ -86,11 +88,13 @@ class AClass {
       final str = specToString(classDefinitionToSpec(definition));
 
       expect(str, '''@JsonSerializable(explicitToJson: true)
-class AClass extends AnotherClass {
+class AClass extends AnotherClass with EquatableMixin {
   AClass();
 
   factory AClass.fromJson(Map<String, dynamic> json) => _\$AClassFromJson(json);
 
+  @override
+  List<Object> get props => [];
   Map<String, dynamic> toJson() => _\$AClassToJson(this);
 }
 ''');
@@ -109,7 +113,7 @@ class AClass extends AnotherClass {
       final str = specToString(classDefinitionToSpec(definition));
 
       expect(str, '''@JsonSerializable(explicitToJson: true)
-class AClass {
+class AClass with EquatableMixin {
   AClass();
 
   factory AClass.fromJson(Map<String, dynamic> json) {
@@ -123,6 +127,8 @@ class AClass {
     return _\$AClassFromJson(json);
   }
 
+  @override
+  List<Object> get props => [];
   Map<String, dynamic> toJson() {
     switch (resolveType) {
       case 'ASubClass':
@@ -146,7 +152,7 @@ class AClass {
       final str = specToString(classDefinitionToSpec(definition));
 
       expect(str, '''@JsonSerializable(explicitToJson: true)
-class AClass {
+class AClass with EquatableMixin {
   AClass();
 
   factory AClass.fromJson(Map<String, dynamic> json) => _\$AClassFromJson(json);
@@ -155,6 +161,8 @@ class AClass {
 
   AnotherType anotherName;
 
+  @override
+  List<Object> get props => [name, anotherName];
   Map<String, dynamic> toJson() => _\$AClassToJson(this);
 }
 ''');
@@ -173,7 +181,7 @@ class AClass {
       final str = specToString(classDefinitionToSpec(definition));
 
       expect(str, '''@JsonSerializable(explicitToJson: true)
-class AClass {
+class AClass with EquatableMixin {
   AClass();
 
   factory AClass.fromJson(Map<String, dynamic> json) => _\$AClassFromJson(json);
@@ -190,6 +198,8 @@ class AClass {
   @Ho()
   AllAtOnce name;
 
+  @override
+  List<Object> get props => [name, name, name, name];
   Map<String, dynamic> toJson() => _\$AClassToJson(this);
 }
 ''');
@@ -236,6 +246,7 @@ class AClass {
       expect(buffer.toString(), '''// GENERATED CODE - DO NOT MODIFY BY HAND
 
 import \'package:json_annotation/json_annotation.dart\';
+import \'package:equatable/equatable.dart\';
 part \'test_query.query.g.dart\';
 ''');
     });
@@ -251,6 +262,7 @@ part \'test_query.query.g.dart\';
       expect(buffer.toString(), '''// GENERATED CODE - DO NOT MODIFY BY HAND
 
 import \'package:json_annotation/json_annotation.dart\';
+import \'package:equatable/equatable.dart\';
 import \'some_file.dart\';
 part \'test_query.query.g.dart\';
 ''');
@@ -268,6 +280,7 @@ part \'test_query.query.g.dart\';
 
 import 'package:artemis/artemis.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
 part 'test_query.query.g.dart';
 
 class TestQueryQuery extends GraphQLQuery<TestQuery, JsonSerializable> {
@@ -279,6 +292,8 @@ class TestQueryQuery extends GraphQLQuery<TestQuery, JsonSerializable> {
   @override
   final String operationName = 'test_query';
 
+  @override
+  List<Object> get props => [query, operationName];
   @override
   TestQuery parse(Map<String, dynamic> json) => TestQuery.fromJson(json);
 }
@@ -297,10 +312,11 @@ class TestQueryQuery extends GraphQLQuery<TestQuery, JsonSerializable> {
 
 import 'package:artemis/artemis.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
 part 'test_query.query.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class TestQueryArguments extends JsonSerializable {
+class TestQueryArguments extends JsonSerializable with EquatableMixin {
   TestQueryArguments({this.name});
 
   factory TestQueryArguments.fromJson(Map<String, dynamic> json) =>
@@ -308,6 +324,8 @@ class TestQueryArguments extends JsonSerializable {
 
   final Type name;
 
+  @override
+  List<Object> get props => [name];
   Map<String, dynamic> toJson() => _\$TestQueryArgumentsToJson(this);
 }
 
@@ -324,6 +342,8 @@ class TestQueryQuery extends GraphQLQuery<TestQuery, TestQueryArguments> {
   final TestQueryArguments variables;
 
   @override
+  List<Object> get props => [query, operationName, variables];
+  @override
   TestQuery parse(Map<String, dynamic> json) => TestQuery.fromJson(json);
 }
 ''');
@@ -337,7 +357,7 @@ class TestQueryQuery extends GraphQLQuery<TestQuery, TestQueryArguments> {
       final str = specToString(generateArgumentClassSpec(definition));
 
       expect(str, '''@JsonSerializable(explicitToJson: true)
-class TestQueryArguments extends JsonSerializable {
+class TestQueryArguments extends JsonSerializable with EquatableMixin {
   TestQueryArguments({this.name});
 
   factory TestQueryArguments.fromJson(Map<String, dynamic> json) =>
@@ -345,6 +365,8 @@ class TestQueryArguments extends JsonSerializable {
 
   final Type name;
 
+  @override
+  List<Object> get props => [name];
   Map<String, dynamic> toJson() => _\$TestQueryArgumentsToJson(this);
 }
 ''');
@@ -371,6 +393,8 @@ class TestQueryArguments extends JsonSerializable {
   final TestQueryArguments variables;
 
   @override
+  List<Object> get props => [query, operationName, variables];
+  @override
   TestQuery parse(Map<String, dynamic> json) => TestQuery.fromJson(json);
 }
 ''');
@@ -390,14 +414,17 @@ class TestQueryArguments extends JsonSerializable {
       expect(buffer.toString(), '''// GENERATED CODE - DO NOT MODIFY BY HAND
 
 import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
 part 'test_query.query.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class AClass {
+class AClass with EquatableMixin {
   AClass();
 
   factory AClass.fromJson(Map<String, dynamic> json) => _\$AClassFromJson(json);
 
+  @override
+  List<Object> get props => [];
   Map<String, dynamic> toJson() => _\$AClassToJson(this);
 }
 

--- a/test/query_generator/query_generator_test.dart
+++ b/test/query_generator/query_generator_test.dart
@@ -70,10 +70,11 @@ void main() {
         'a|some_query.query.dart': '''// GENERATED CODE - DO NOT MODIFY BY HAND
 
 import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
 part 'some_query.query.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery {
+class SomeQuery with EquatableMixin {
   SomeQuery();
 
   factory SomeQuery.fromJson(Map<String, dynamic> json) =>
@@ -83,6 +84,8 @@ class SomeQuery {
 
   int i;
 
+  @override
+  List<Object> get props => [s, i];
   Map<String, dynamic> toJson() => _\$SomeQueryToJson(this);
 }
 ''',
@@ -184,10 +187,11 @@ class SomeQuery {
         'a|some_query.query.dart': '''// GENERATED CODE - DO NOT MODIFY BY HAND
 
 import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
 part 'some_query.query.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery {
+class SomeQuery with EquatableMixin {
   SomeQuery();
 
   factory SomeQuery.fromJson(Map<String, dynamic> json) =>
@@ -197,11 +201,13 @@ class SomeQuery {
 
   SomeObject o;
 
+  @override
+  List<Object> get props => [s, o];
   Map<String, dynamic> toJson() => _\$SomeQueryToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeObject {
+class SomeObject with EquatableMixin {
   SomeObject();
 
   factory SomeObject.fromJson(Map<String, dynamic> json) =>
@@ -211,11 +217,13 @@ class SomeObject {
 
   List<AnotherObject> ob;
 
+  @override
+  List<Object> get props => [st, ob];
   Map<String, dynamic> toJson() => _\$SomeObjectToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)
-class AnotherObject {
+class AnotherObject with EquatableMixin {
   AnotherObject();
 
   factory AnotherObject.fromJson(Map<String, dynamic> json) =>
@@ -223,6 +231,8 @@ class AnotherObject {
 
   String str;
 
+  @override
+  List<Object> get props => [str];
   Map<String, dynamic> toJson() => _\$AnotherObjectToJson(this);
 }
 ''',
@@ -281,10 +291,11 @@ class AnotherObject {
         'a|some_query.query.dart': '''// GENERATED CODE - DO NOT MODIFY BY HAND
 
 import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
 part 'some_query.query.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery {
+class SomeQuery with EquatableMixin {
   SomeQuery();
 
   factory SomeQuery.fromJson(Map<String, dynamic> json) =>
@@ -294,6 +305,8 @@ class SomeQuery {
 
   String lastName;
 
+  @override
+  List<Object> get props => [firstName, lastName];
   Map<String, dynamic> toJson() => _\$SomeQueryToJson(this);
 }
 ''',
@@ -391,10 +404,11 @@ class SomeQuery {
         'a|some_query.query.dart': '''// GENERATED CODE - DO NOT MODIFY BY HAND
 
 import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
 part 'some_query.query.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery {
+class SomeQuery with EquatableMixin {
   SomeQuery();
 
   factory SomeQuery.fromJson(Map<String, dynamic> json) =>
@@ -406,11 +420,13 @@ class SomeQuery {
 
   List<AnotherObject> anotherObject;
 
+  @override
+  List<Object> get props => [s, o, anotherObject];
   Map<String, dynamic> toJson() => _\$SomeQueryToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeObject {
+class SomeObject with EquatableMixin {
   SomeObject();
 
   factory SomeObject.fromJson(Map<String, dynamic> json) =>
@@ -418,11 +434,13 @@ class SomeObject {
 
   String st;
 
+  @override
+  List<Object> get props => [st];
   Map<String, dynamic> toJson() => _\$SomeObjectToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)
-class AnotherObject {
+class AnotherObject with EquatableMixin {
   AnotherObject();
 
   factory AnotherObject.fromJson(Map<String, dynamic> json) =>
@@ -430,6 +448,8 @@ class AnotherObject {
 
   String str;
 
+  @override
+  List<Object> get props => [str];
   Map<String, dynamic> toJson() => _\$AnotherObjectToJson(this);
 }
 ''',
@@ -526,10 +546,11 @@ class AnotherObject {
 
 import 'package:artemis/artemis.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
 part 'some_query.query.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery {
+class SomeQuery with EquatableMixin {
   SomeQuery();
 
   factory SomeQuery.fromJson(Map<String, dynamic> json) =>
@@ -541,11 +562,13 @@ class SomeQuery {
 
   List<AnotherObject> anotherObject;
 
+  @override
+  List<Object> get props => [s, o, anotherObject];
   Map<String, dynamic> toJson() => _\$SomeQueryToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeObject {
+class SomeObject with EquatableMixin {
   SomeObject();
 
   factory SomeObject.fromJson(Map<String, dynamic> json) =>
@@ -553,11 +576,13 @@ class SomeObject {
 
   String st;
 
+  @override
+  List<Object> get props => [st];
   Map<String, dynamic> toJson() => _\$SomeObjectToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)
-class AnotherObject {
+class AnotherObject with EquatableMixin {
   AnotherObject();
 
   factory AnotherObject.fromJson(Map<String, dynamic> json) =>
@@ -565,6 +590,8 @@ class AnotherObject {
 
   String str;
 
+  @override
+  List<Object> get props => [str];
   Map<String, dynamic> toJson() => _\$AnotherObjectToJson(this);
 }
 
@@ -578,6 +605,8 @@ class SomeQueryQuery extends GraphQLQuery<SomeQuery, JsonSerializable> {
   @override
   final String operationName = 'some_query';
 
+  @override
+  List<Object> get props => [query, operationName];
   @override
   SomeQuery parse(Map<String, dynamic> json) => SomeQuery.fromJson(json);
 }
@@ -676,11 +705,12 @@ class SomeQueryQuery extends GraphQLQuery<SomeQuery, JsonSerializable> {
         'a|some_query.query.dart': '''// GENERATED CODE - DO NOT MODIFY BY HAND
 
 import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
 import 'package:decimal/decimal.dart';
 part 'some_query.query.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery {
+class SomeQuery with EquatableMixin {
   SomeQuery();
 
   factory SomeQuery.fromJson(Map<String, dynamic> json) =>
@@ -690,6 +720,8 @@ class SomeQuery {
 
   DateTime dateTime;
 
+  @override
+  List<Object> get props => [bigDecimal, dateTime];
   Map<String, dynamic> toJson() => _\$SomeQueryToJson(this);
 }
 ''',


### PR DESCRIPTION
This PR proposes making all generated classes have the `==` and `hashCode` methods implemented so we can easily make comparisons against different instances of them.

I am using the `equatable` package to facilitate the code generation required to make this work.