### PR TITLE
Upgrade `gql` to version `0.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### Next
+- Upgrade `gql` to version `0.2.0` to get rid of direct dependency on `source_span`
+  and for better parsing errors.
+
 ## 1.0.0
 - Breaking: Add required `output` option to `SchemaMap`
 - Make Artemis a `$lib$` synthetic generator

--- a/example/graphbrainz/pubspec.lock
+++ b/example/graphbrainz/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.7.0"
+    version: "1.0.0"
   async:
     dependency: transitive
     description:
@@ -70,14 +70,14 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.7"
+    version: "1.6.9"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.9"
+    version: "3.1.1"
   built_collection:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   csslib:
     dependency: transitive
     description:
@@ -182,7 +182,7 @@ packages:
       name: gql
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.2.0"
   graphs:
     dependency: transitive
     description:
@@ -301,7 +301,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.7"
+    version: "1.4.8"
   package_config:
     dependency: transitive
     description:
@@ -462,7 +462,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.8"
+    version: "1.6.9"
   test_api:
     dependency: transitive
     description:
@@ -497,7 +497,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
   watcher:
     dependency: transitive
     description:

--- a/example/pokemon/pubspec.lock
+++ b/example/pokemon/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.7.0"
+    version: "1.0.0"
   async:
     dependency: transitive
     description:
@@ -70,14 +70,14 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.7"
+    version: "1.6.9"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.9"
+    version: "3.1.1"
   built_collection:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   csslib:
     dependency: transitive
     description:
@@ -182,7 +182,7 @@ packages:
       name: gql
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.2.0"
   graphs:
     dependency: transitive
     description:
@@ -294,7 +294,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.7"
+    version: "1.4.8"
   package_config:
     dependency: transitive
     description:
@@ -455,7 +455,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.8"
+    version: "1.6.9"
   test_api:
     dependency: transitive
     description:
@@ -490,7 +490,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
   watcher:
     dependency: transitive
     description:

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -1,7 +1,6 @@
 import 'package:path/path.dart' as p;
 import 'package:gql/ast.dart';
 import 'package:gql/language.dart';
-import 'package:source_span/source_span.dart';
 import 'package:recase/recase.dart';
 import './schema/options.dart';
 import './schema/graphql.dart';
@@ -10,13 +9,13 @@ import './generator/helpers.dart';
 import './generator/graphql_helpers.dart' as gql;
 
 OperationDefinitionNode _getOperationFromQuery(String queryStr) {
-  final doc = parse(SourceFile.fromString(queryStr));
+  final doc = parseString(queryStr);
 
   return doc.definitions.whereType<OperationDefinitionNode>().first;
 }
 
 List<FragmentDefinitionNode> _getFragmentsFromQuery(String queryStr) {
-  final doc = parse(SourceFile.fromString(queryStr));
+  final doc = parseString(queryStr);
 
   return doc.definitions.whereType<FragmentDefinitionNode>().toList();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,9 +16,8 @@ dependencies:
   build_config: ^0.4.0
   source_gen: ^0.9.4+2
   path: ^1.6.2
-  gql: ^0.1.0
+  gql: ^0.2.0
   equatable: ^0.5.1
-  source_span: ^1.5.5
   recase: ^2.0.1
   glob: ^1.1.7
   code_builder: ^3.2.0


### PR DESCRIPTION
Upgrade `gql` to version `0.2.0` to get rid of direct dependency on `source_span` and for better parsing errors.