### PR TITLE
Loosen up analyzer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.0.1
+- Loosen up dependencies to make it work again with Flutter `beta` channel
+
 ## 2.0.0
 - BREAKING: move `GraphQLError` to `package:gql`. If you don't use it, or just
   reference it indirectly, it will not be breaking, but a major will be bumped

--- a/example/graphbrainz/pubspec.lock
+++ b/example/graphbrainz/pubspec.lock
@@ -154,7 +154,7 @@ packages:
       name: equatable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.1"
   fixnum:
     dependency: transitive
     description:
@@ -182,21 +182,28 @@ packages:
       name: gql
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.4"
+    version: "0.9.0"
+  gql_code_gen:
+    dependency: transitive
+    description:
+      name: gql_code_gen
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   gql_dedupe_link:
     dependency: transitive
     description:
       name: gql_dedupe_link
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.3"
   gql_http_link:
     dependency: transitive
     description:
       name: gql_http_link
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.2"
   graphs:
     dependency: transitive
     description:

--- a/example/pokemon/pubspec.lock
+++ b/example/pokemon/pubspec.lock
@@ -154,7 +154,7 @@ packages:
       name: equatable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.1"
   fixnum:
     dependency: transitive
     description:
@@ -182,21 +182,28 @@ packages:
       name: gql
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.4"
+    version: "0.9.0"
+  gql_code_gen:
+    dependency: transitive
+    description:
+      name: gql_code_gen
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   gql_dedupe_link:
     dependency: transitive
     description:
       name: gql_dedupe_link
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.3"
   gql_http_link:
     dependency: transitive
     description:
       name: gql_http_link
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.2"
   graphs:
     dependency: transitive
     description:

--- a/lib/generator/print_helpers.dart
+++ b/lib/generator/print_helpers.dart
@@ -1,6 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
-import 'package:gql/dart.dart' as dart;
+import 'package:gql_code_gen/gql_code_gen.dart' as dart;
 import 'package:recase/recase.dart';
 
 import '../generator/data.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   gql: '>=0.7.3 <1.0.0'
   gql_dedupe_link: ^1.0.0
   gql_http_link: ^0.1.0
-  equatable: ^0.5.1
+  equatable: ^0.6.1
   recase: ^2.0.1
   glob: ^1.1.7
   code_builder: ^3.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 2.0.0
+version: 2.0.1
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  # analyzer: ^0.37.0
   build: ^1.1.4
   build_config: ^0.4.0
   source_gen: ^0.9.4+2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,24 +11,24 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  build: ^1.1.4
   build_config: ^0.4.0
-  source_gen: ^0.9.4+2
-  path: ^1.6.2
-  gql: '>=0.7.3 <1.0.0'
+  build: ^1.1.4
+  code_builder: ^3.2.0
+  equatable: ^0.6.1
+  glob: ^1.1.7
   gql_dedupe_link: ^1.0.0
   gql_http_link: ^0.1.0
-  equatable: ^0.6.1
-  recase: ^2.0.1
-  glob: ^1.1.7
-  code_builder: ^3.2.0
+  gql: '>=0.7.3 <1.0.0'
   http: ^0.12.0+2
   meta: ^1.1.7
+  path: ^1.6.2
+  recase: ^2.0.1
+  source_gen: ^0.9.4+2
 
 dev_dependencies:
   args: ^1.5.2
   build_runner: ^1.5.0
-  json_serializable: ^3.0.0
-  test: ^1.6.3
   build_test: ^0.10.7+3
+  json_serializable: ^3.0.0
   pedantic: ^1.8.0+1
+  test: ^1.6.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,9 +16,9 @@ dependencies:
   code_builder: ^3.2.0
   equatable: ^0.6.1
   glob: ^1.1.7
-  gql_dedupe_link: ^1.0.0
-  gql_http_link: ^0.1.0
-  gql: '>=0.7.3 <1.0.0'
+  gql_dedupe_link: ^1.0.3
+  gql_http_link: ^0.1.2
+  gql: ^0.9.0
   http: ^0.12.0+2
   meta: ^1.1.7
   path: ^1.6.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.38.2
+  # analyzer: ^0.37.0
   build: ^1.1.4
   build_config: ^0.4.0
   source_gen: ^0.9.4+2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   code_builder: ^3.2.0
   equatable: ^0.6.1
   glob: ^1.1.7
+  gql_code_gen: ^0.1.0
   gql_dedupe_link: ^1.0.3
   gql_http_link: ^0.1.2
   gql: ^0.9.0


### PR DESCRIPTION
Although this is a Dart-only library, it's good to be in sync with at least flutter `beta` branch.

`flutter_test` from Flutter SDK doesn't have all its dependencies up-to-date (we're getting conflicts with `analyzer`). As `analyzer` is not used directly by Artemis, it doesn't make sense to force version `0.38.2`.