### PR TITLE
Generate every field of input objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.0.3
+- Generate every field of input objects
+
 ## 2.0.2
 - Support `__schema` key under the data field or on root of `schema.json`.
 

--- a/example/graphbrainz/pubspec.lock
+++ b/example/graphbrainz/pubspec.lock
@@ -2,7 +2,7 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages:
   analyzer:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
@@ -21,7 +21,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.2"
   async:
     dependency: transitive
     description:

--- a/example/graphbrainz/pubspec.yaml
+++ b/example/graphbrainz/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   intl: ^0.15.8
 
 dev_dependencies:
-  analyzer: 0.38.2 # avoid bug https://github.com/dart-lang/build/issues/2451
   test: ^1.6.3
   build_runner: ^1.5.0
   json_serializable: ^3.0.0

--- a/example/pokemon/pubspec.lock
+++ b/example/pokemon/pubspec.lock
@@ -2,7 +2,7 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages:
   analyzer:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
@@ -21,7 +21,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.2"
   async:
     dependency: transitive
     description:

--- a/example/pokemon/pubspec.yaml
+++ b/example/pokemon/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
   http: ^0.12.0+2
 
 dev_dependencies:
-  analyzer: 0.38.2 # avoid bug https://github.com/dart-lang/build/issues/2451
   test: ^1.6.3
   build_runner: ^1.5.0
   json_serializable: ^3.0.0

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -243,21 +243,19 @@ List<Definition> _extractClasses(
         options,
         prefix: prefix,
         onNewClassFound: (selectionSet, className, type) {
-          if (type.kind == GraphQLTypeKind.INPUT_OBJECT) {
-            queue.addAll(
-              _extractClasses(
-                null,
-                fragments,
-                schema,
-                className,
-                type,
-                options,
-                schemaMap,
-                prefix: prefix,
-                parentSelectionSet: selectionSet,
-              ),
-            );
-          }
+          queue.addAll(
+            _extractClasses(
+              null,
+              fragments,
+              schema,
+              className,
+              type,
+              options,
+              schemaMap,
+              prefix: prefix,
+              parentSelectionSet: selectionSet,
+            ),
+          );
         },
       );
     }).toList();
@@ -273,7 +271,7 @@ List<Definition> _extractClasses(
     return [
       EnumDefinition(
         currentType.name,
-        currentType.enumValues.map((eV) => eV.name),
+        currentType.enumValues.map((eV) => eV.name).toList(),
       ),
     ];
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 2.0.2
+version: 2.0.3
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/test/query_generator/complex_input_objects_test.dart
+++ b/test/query_generator/complex_input_objects_test.dart
@@ -1,0 +1,145 @@
+import 'dart:convert';
+
+import 'package:artemis/builder.dart';
+import 'package:artemis/generator/data.dart';
+import 'package:artemis/schema/graphql.dart';
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:gql/language.dart';
+import 'package:test/test.dart';
+
+String jsonFromSchema(GraphQLSchema schema) => json.encode({
+      'data': {'__schema': schema.toJson()}
+    });
+
+void main() {
+  test('On complex input objects', () async {
+    final GraphQLQueryBuilder anotherBuilder =
+        graphQLQueryBuilder(BuilderOptions({
+      'generate_helpers': false,
+      'schema_mapping': [
+        {
+          'schema': 'api.schema.json',
+          'queries_glob': '**.graphql',
+          'output': 'lib/some_query.dart',
+        }
+      ]
+    }));
+    final GraphQLSchema schema = GraphQLSchema(
+      queryType: GraphQLType(name: 'SomeObject', kind: GraphQLTypeKind.OBJECT),
+      types: [
+        GraphQLType(name: 'String', kind: GraphQLTypeKind.SCALAR),
+        GraphQLType(name: 'MyEnum', kind: GraphQLTypeKind.ENUM, enumValues: [
+          GraphQLEnumValue(name: 'value1'),
+          GraphQLEnumValue(name: 'value2'),
+        ]),
+        GraphQLType(
+            name: 'ComplexType',
+            kind: GraphQLTypeKind.INPUT_OBJECT,
+            inputFields: [
+              GraphQLInputValue(
+                  name: 's',
+                  type: GraphQLType(
+                      name: 'String', kind: GraphQLTypeKind.SCALAR)),
+              GraphQLInputValue(
+                  name: 'e',
+                  type:
+                      GraphQLType(name: 'MyEnum', kind: GraphQLTypeKind.ENUM)),
+            ]),
+        GraphQLType(name: 'SomeObject', kind: GraphQLTypeKind.OBJECT, fields: [
+          GraphQLField(
+              name: 's',
+              type: GraphQLType(name: 'String', kind: GraphQLTypeKind.SCALAR)),
+        ]),
+      ],
+    );
+
+    anotherBuilder.onBuild = expectAsync1((definition) {
+      final libraryDefinition = LibraryDefinition(
+        'some_query',
+        queries: [
+          QueryDefinition(
+            'SomeQuery',
+            parseString('query some_query(\$filter: ComplexType!) { s }'),
+            inputs: [QueryInput('ComplexType', 'filter')],
+            classes: [
+              ClassDefinition('SomeQuery', [
+                ClassProperty('String', 's'),
+              ]),
+              ClassDefinition('ComplexType', [
+                ClassProperty('String', 's'),
+                ClassProperty('MyEnum', 'e'),
+              ]),
+              EnumDefinition('MyEnum', ['value1', 'value2']),
+            ],
+          ),
+        ],
+      );
+
+      expect(definition, libraryDefinition);
+    }, count: 1);
+
+    await testBuilder(anotherBuilder, {
+      'a|api.schema.json': jsonFromSchema(schema),
+      'a|some_query.query.graphql':
+          'query some_query(\$filter: ComplexType!) { s }',
+    }, outputs: {
+      'a|lib/some_query.dart': '''// GENERATED CODE - DO NOT MODIFY BY HAND
+
+import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
+import 'package:gql/ast.dart';
+part 'some_query.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class SomeQuery with EquatableMixin {
+  SomeQuery();
+
+  factory SomeQuery.fromJson(Map<String, dynamic> json) =>
+      _\$SomeQueryFromJson(json);
+
+  String s;
+
+  @override
+  List<Object> get props => [s];
+  Map<String, dynamic> toJson() => _\$SomeQueryToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class ComplexType with EquatableMixin {
+  ComplexType();
+
+  factory ComplexType.fromJson(Map<String, dynamic> json) =>
+      _\$ComplexTypeFromJson(json);
+
+  String s;
+
+  MyEnum e;
+
+  @override
+  List<Object> get props => [s, e];
+  Map<String, dynamic> toJson() => _\$ComplexTypeToJson(this);
+}
+
+enum MyEnum {
+  value1,
+  value2,
+}
+
+@JsonSerializable(explicitToJson: true)
+class SomeQueryArguments extends JsonSerializable with EquatableMixin {
+  SomeQueryArguments({this.filter});
+
+  factory SomeQueryArguments.fromJson(Map<String, dynamic> json) =>
+      _\$SomeQueryArgumentsFromJson(json);
+
+  final ComplexType filter;
+
+  @override
+  List<Object> get props => [filter];
+  Map<String, dynamic> toJson() => _\$SomeQueryArgumentsToJson(this);
+}
+''',
+    });
+  });
+}


### PR DESCRIPTION
Previously, input objects fields' were only generating code for other input objects. This change makes it generates code for everything (objects, enum, etc).

Fixes https://github.com/comigor/artemis/issues/37