### PR TITLE
preserver query name casing

### DIFF
--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -67,13 +67,14 @@ QueryDefinition generateQuery(
 
   final basename = p.basenameWithoutExtension(path);
   final queryName = operation.name?.value ?? basename;
+  final className = ReCase(queryName).pascalCase;
 
   GraphQLType parentType = gql.getTypeByName(schema, schema.queryType.name);
   if (operation.type == OperationType.mutation) {
     parentType = gql.getTypeByName(schema, schema.mutationType.name);
   }
 
-  final prefix = schemaMap.addQueryPrefix ? queryName : '';
+  final prefix = schemaMap.addQueryPrefix ? className : '';
 
   final List<QueryInput> inputs = [];
   final List<Definition> inputsClasses = [];
@@ -95,7 +96,6 @@ QueryDefinition generateQuery(
     });
   }
 
-  final className = ReCase(queryName).pascalCase;
   final classes = _extractClasses(
     operation.selectionSet,
     fragments,

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -66,7 +66,7 @@ QueryDefinition generateQuery(
       document.definitions.whereType<FragmentDefinitionNode>().toList();
 
   final basename = p.basenameWithoutExtension(path);
-  final queryName = ReCase(operation.name?.value ?? basename).pascalCase;
+  final queryName = operation.name?.value ?? basename;
 
   GraphQLType parentType = gql.getTypeByName(schema, schema.queryType.name);
   if (operation.type == OperationType.mutation) {
@@ -95,11 +95,12 @@ QueryDefinition generateQuery(
     });
   }
 
+  final className = ReCase(queryName).pascalCase;
   final classes = _extractClasses(
     operation.selectionSet,
     fragments,
     schema,
-    queryName,
+    className,
     parentType,
     options,
     schemaMap,

--- a/lib/generator/data.dart
+++ b/lib/generator/data.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
+import 'package:recase/recase.dart';
 
 import '../schema/graphql.dart';
 
@@ -145,6 +146,9 @@ class QueryDefinition extends Equatable {
 
   /// If instances of [GraphQLQuery] should be generated.
   final bool generateHelpers;
+
+  /// The class name.
+  String get className => ReCase(queryName).pascalCase;
 
   /// Instantiate a query definition.
   QueryDefinition(

--- a/lib/generator/print_helpers.dart
+++ b/lib/generator/print_helpers.dart
@@ -131,7 +131,7 @@ Spec generateArgumentClassSpec(QueryDefinition definition) {
     (b) => b
       ..annotations
           .add(CodeExpression(Code('JsonSerializable(explicitToJson: true)')))
-      ..name = '${definition.queryName}Arguments'
+      ..name = '${definition.className}Arguments'
       ..extend = refer('JsonSerializable')
       ..mixins.add(refer('EquatableMixin'))
       ..methods.add(_propsMethod(
@@ -157,14 +157,14 @@ Spec generateArgumentClassSpec(QueryDefinition definition) {
               ..type = refer('Map<String, dynamic>')
               ..name = 'json',
           ))
-          ..body = Code('_\$${definition.queryName}ArgumentsFromJson(json)'),
+          ..body = Code('_\$${definition.className}ArgumentsFromJson(json)'),
       ))
       ..methods.add(Method(
         (m) => m
           ..name = 'toJson'
           ..lambda = true
           ..returns = refer('Map<String, dynamic>')
-          ..body = Code('_\$${definition.queryName}ArgumentsToJson(this)'),
+          ..body = Code('_\$${definition.className}ArgumentsToJson(this)'),
       ))
       ..fields.addAll(definition.inputs.map(
         (p) => Field(
@@ -180,8 +180,8 @@ Spec generateArgumentClassSpec(QueryDefinition definition) {
 /// Generates a [Spec] of a query/mutation class.
 Spec generateQueryClassSpec(QueryDefinition definition) {
   final String typeDeclaration = definition.inputs.isEmpty
-      ? '${definition.queryName}, JsonSerializable'
-      : '${definition.queryName}, ${definition.queryName}Arguments';
+      ? '${definition.className}, JsonSerializable'
+      : '${definition.className}, ${definition.className}Arguments';
 
   final constructor = definition.inputs.isEmpty
       ? Constructor()
@@ -208,7 +208,7 @@ Spec generateQueryClassSpec(QueryDefinition definition) {
         ..modifier = FieldModifier.final$
         ..type = refer('String')
         ..name = 'operationName'
-        ..assignment = Code('\'${ReCase(definition.queryName).snakeCase}\''),
+        ..assignment = Code('\'${definition.queryName}\''),
     ),
   ];
 
@@ -217,14 +217,14 @@ Spec generateQueryClassSpec(QueryDefinition definition) {
       (f) => f
         ..annotations.add(CodeExpression(Code('override')))
         ..modifier = FieldModifier.final$
-        ..type = refer('${definition.queryName}Arguments')
+        ..type = refer('${definition.className}Arguments')
         ..name = 'variables',
     ));
   }
 
   return Class(
     (b) => b
-      ..name = '${definition.queryName}Query'
+      ..name = '${definition.className}Query'
       ..extend = refer('GraphQLQuery<$typeDeclaration>')
       ..constructors.add(constructor)
       ..fields.addAll(fields)
@@ -233,7 +233,7 @@ Spec generateQueryClassSpec(QueryDefinition definition) {
       ..methods.add(Method(
         (m) => m
           ..annotations.add(CodeExpression(Code('override')))
-          ..returns = refer(definition.queryName)
+          ..returns = refer(definition.className)
           ..name = 'parse'
           ..requiredParameters.add(Parameter(
             (p) => p
@@ -241,7 +241,7 @@ Spec generateQueryClassSpec(QueryDefinition definition) {
               ..name = 'json',
           ))
           ..lambda = true
-          ..body = Code('${definition.queryName}.fromJson(json)'),
+          ..body = Code('${definition.className}.fromJson(json)'),
       )),
   );
 }

--- a/lib/generator/print_helpers.dart
+++ b/lib/generator/print_helpers.dart
@@ -1,7 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:gql_code_gen/gql_code_gen.dart' as dart;
-import 'package:recase/recase.dart';
 
 import '../generator/data.dart';
 import '../generator/helpers.dart';

--- a/test/generator/print_helpers_test.dart
+++ b/test/generator/print_helpers_test.dart
@@ -232,7 +232,7 @@ class AClass with EquatableMixin {
       );
       expect(
         () => generateQueryClassSpec(
-          QueryDefinition('TestQuery', null),
+          QueryDefinition('test_query', null),
         ),
         throwsA(
           TypeMatcher<AssertionError>(),
@@ -278,7 +278,7 @@ part 'test_query.g.dart';
         'test_query',
         queries: [
           QueryDefinition(
-            'TestQuery',
+            'test_query',
             parseString('query test_query {}'),
             generateHelpers: true,
           )
@@ -323,7 +323,7 @@ class TestQueryQuery extends GraphQLQuery<TestQuery, JsonSerializable> {
       final buffer = StringBuffer();
       final definition = LibraryDefinition('test_query', queries: [
         QueryDefinition(
-          'TestQuery',
+          'test_query',
           parseString('query test_query {}'),
           generateHelpers: true,
           inputs: [QueryInput('Type', 'name')],
@@ -383,7 +383,7 @@ class TestQueryQuery extends GraphQLQuery<TestQuery, TestQueryArguments> {
 
     test('Will generate an Arguments class', () {
       final definition = QueryDefinition(
-        'TestQuery',
+        'test_query',
         parseString('query test_query {}'),
         generateHelpers: true,
         inputs: [QueryInput('Type', 'name')],
@@ -409,7 +409,7 @@ class TestQueryArguments extends JsonSerializable with EquatableMixin {
 
     test('Will generate a Query Class', () {
       final definition = QueryDefinition(
-        'TestQuery',
+        'test_query',
         parseString('query test_query {}'),
         generateHelpers: true,
         inputs: [QueryInput('Type', 'name')],
@@ -449,7 +449,7 @@ class TestQueryArguments extends JsonSerializable with EquatableMixin {
       final buffer = StringBuffer();
       final definition = LibraryDefinition('test_query', queries: [
         QueryDefinition(
-          'TestQuery',
+          'test_query',
           parseString('query test_query {}'),
           classes: [
             EnumDefinition('Enum', ['Value']),

--- a/test/query_generator/complex_input_objects_test.dart
+++ b/test/query_generator/complex_input_objects_test.dart
@@ -59,7 +59,7 @@ void main() {
         'some_query',
         queries: [
           QueryDefinition(
-            'SomeQuery',
+            'some_query',
             parseString('query some_query(\$filter: ComplexType!) { s }'),
             inputs: [QueryInput('ComplexType', 'filter')],
             classes: [

--- a/test/query_generator/multiple_queries_test.dart
+++ b/test/query_generator/multiple_queries_test.dart
@@ -53,7 +53,7 @@ void main() {
           'graphql_api',
           queries: [
             QueryDefinition(
-              'SomeQuery',
+              'some_query',
               parseString('query some_query { s, i }'),
               classes: [
                 ClassDefinition('SomeQuery', [
@@ -63,7 +63,7 @@ void main() {
               ],
             ),
             QueryDefinition(
-              'AnotherQuery',
+              'another_query',
               parseString('query another_query { s }'),
               classes: [
                 ClassDefinition('AnotherQuery', [
@@ -200,7 +200,7 @@ class AnotherQuery with EquatableMixin {
             'graphql_api',
             queries: [
               QueryDefinition(
-                'SomeQuery',
+                'some_query',
                 parseString('query some_query { i, obj { str } }'),
                 classes: [
                   ClassDefinition('SomeQuery', [
@@ -213,7 +213,7 @@ class AnotherQuery with EquatableMixin {
                 ],
               ),
               QueryDefinition(
-                'AnotherQuery',
+                'another_query',
                 parseString('query another_query { s, obj { str } }'),
                 classes: [
                   ClassDefinition('AnotherQuery', [

--- a/test/query_generator/query_generator_test.dart
+++ b/test/query_generator/query_generator_test.dart
@@ -86,7 +86,7 @@ void main() {
             'some_query',
             queries: [
               QueryDefinition(
-                'SomeQuery',
+                'some_query',
                 parseString('query some_query { s, i }'),
                 classes: [
                   ClassDefinition('SomeQuery', [
@@ -190,7 +190,7 @@ class SomeQuery with EquatableMixin {
           'some_query',
           queries: [
             QueryDefinition(
-              'SomeQuery',
+              'some_query',
               parseString(
                   'query some_query(\$ints: [Int]!) { s, i, list(ints: \$ints) }'),
               inputs: [QueryInput('int', 'ints')],
@@ -326,7 +326,7 @@ class SomeQueryArguments extends JsonSerializable with EquatableMixin {
             'some_query',
             queries: [
               QueryDefinition(
-                'SomeQuery',
+                'some_query',
                 parseString(document),
                 classes: [
                   ClassDefinition('SomeQuery', [
@@ -442,7 +442,7 @@ class AnotherObject with EquatableMixin {
             'some_query',
             queries: [
               QueryDefinition(
-                'SomeQuery',
+                'some_query',
                 parseString('query some_query { firstName: s, lastName: st }'),
                 classes: [
                   ClassDefinition('SomeQuery', [
@@ -555,7 +555,7 @@ class SomeQuery with EquatableMixin {
             'some_query',
             queries: [
               QueryDefinition(
-                'SomeQuery',
+                'some_query',
                 parseString(document),
                 classes: [
                   ClassDefinition('SomeQuery', [
@@ -701,7 +701,7 @@ class AnotherObject with EquatableMixin {
             'some_query',
             queries: [
               QueryDefinition(
-                'SomeQuery',
+                'some_query',
                 parseString(document),
                 classes: [
                   ClassDefinition('SomeQuery', [
@@ -910,7 +910,7 @@ class SomeQueryQuery extends GraphQLQuery<SomeQuery, JsonSerializable> {
             'some_query',
             queries: [
               QueryDefinition(
-                'SomeQuery',
+                'some_query',
                 parseString('query some_query { bigDecimal, dateTime }'),
                 classes: [
                   ClassDefinition('SomeQuery', [
@@ -1033,7 +1033,7 @@ class SomeQuery with EquatableMixin {
             'some_query',
             queries: [
               QueryDefinition(
-                'SomeQuery',
+                'some_query',
                 parseString(document),
                 classes: [
                   ClassDefinition('SomeQuery', [

--- a/test/query_generator/query_generator_test.dart
+++ b/test/query_generator/query_generator_test.dart
@@ -1118,5 +1118,81 @@ class SomeQueryAnotherObject with EquatableMixin {
           },
           onLog: print);
     });
+
+    test('Query name (pascal casing)', () async {
+      final GraphQLQueryBuilder anotherBuilder =
+      graphQLQueryBuilder(BuilderOptions({
+        'generate_helpers': false,
+        'schema_mapping': [
+          {
+            'schema': 'api.schema.json',
+            'queries_glob': '**.graphql',
+            'output': 'lib/pascal_casing_query.dart',
+          }
+        ]
+      }));
+      final GraphQLSchema schema = GraphQLSchema(
+          queryType:
+          GraphQLType(name: 'PascalCasingQuery', kind: GraphQLTypeKind.OBJECT),
+          types: [
+            GraphQLType(name: 'String', kind: GraphQLTypeKind.SCALAR),
+            GraphQLType(
+                name: 'PascalCasingQuery',
+                kind: GraphQLTypeKind.OBJECT,
+                fields: [
+                  GraphQLField(
+                      name: 's',
+                      type: GraphQLType(
+                          name: 'String', kind: GraphQLTypeKind.SCALAR)),
+                ]),
+          ]);
+
+      anotherBuilder.onBuild = expectAsync1((definition) {
+        expect(
+          definition,
+          LibraryDefinition(
+            'pascal_casing_query',
+            queries: [
+              QueryDefinition(
+                'PascalCasingQuery',
+                parseString('query PascalCasingQuery { s }'),
+                classes: [
+                  ClassDefinition('PascalCasingQuery', [
+                    ClassProperty('String', 's'),
+                  ])
+                ],
+              ),
+            ],
+          ),
+        );
+      }, count: 1);
+
+      await testBuilder(anotherBuilder, {
+        'a|api.schema.json': jsonFromSchema(schema),
+        'a|pascal_casing_query.query.graphql': 'query PascalCasingQuery { s }',
+      }, outputs: {
+        'a|lib/pascal_casing_query.dart': '''// GENERATED CODE - DO NOT MODIFY BY HAND
+
+import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
+import 'package:gql/ast.dart';
+part 'pascal_casing_query.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class PascalCasingQuery with EquatableMixin {
+  PascalCasingQuery();
+
+  factory PascalCasingQuery.fromJson(Map<String, dynamic> json) =>
+      _\$PascalCasingQueryFromJson(json);
+
+  String s;
+
+  @override
+  List<Object> get props => [s];
+  Map<String, dynamic> toJson() => _\$PascalCasingQueryToJson(this);
+}
+''',
+      });
+    });
   });
 }

--- a/test/query_generator/query_generator_test.dart
+++ b/test/query_generator/query_generator_test.dart
@@ -1121,7 +1121,7 @@ class SomeQueryAnotherObject with EquatableMixin {
 
     test('Query name (pascal casing)', () async {
       final GraphQLQueryBuilder anotherBuilder =
-      graphQLQueryBuilder(BuilderOptions({
+          graphQLQueryBuilder(BuilderOptions({
         'generate_helpers': false,
         'schema_mapping': [
           {
@@ -1132,8 +1132,8 @@ class SomeQueryAnotherObject with EquatableMixin {
         ]
       }));
       final GraphQLSchema schema = GraphQLSchema(
-          queryType:
-          GraphQLType(name: 'PascalCasingQuery', kind: GraphQLTypeKind.OBJECT),
+          queryType: GraphQLType(
+              name: 'PascalCasingQuery', kind: GraphQLTypeKind.OBJECT),
           types: [
             GraphQLType(name: 'String', kind: GraphQLTypeKind.SCALAR),
             GraphQLType(
@@ -1171,7 +1171,8 @@ class SomeQueryAnotherObject with EquatableMixin {
         'a|api.schema.json': jsonFromSchema(schema),
         'a|pascal_casing_query.query.graphql': 'query PascalCasingQuery { s }',
       }, outputs: {
-        'a|lib/pascal_casing_query.dart': '''// GENERATED CODE - DO NOT MODIFY BY HAND
+        'a|lib/pascal_casing_query.dart':
+            '''// GENERATED CODE - DO NOT MODIFY BY HAND
 
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';


### PR DESCRIPTION
Perserve the query name casing

The following query now generates code like ```... final String operationName = 'RygappGeral'; ...```

```
query RygappGeral {
  versao
}
```

See issue #26 for more details