### PR TITLE
Add missing prefix to interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 2.0.7
 - Add missing prefix to interfaces
-- Make all class properties camelCased
 
 ## 2.0.6
 - Perserve the query name casing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.0.7
+- Add missing prefix to interfaces
+- Make all class properties camelCased
+
 ## 2.0.6
 - Perserve the query name casing
 

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -176,7 +176,8 @@ ClassProperty _createClassProperty(
         'JsonKey(fromJson: fromGraphQL${graphqlTypeSafeStr}ToDart$dartTypeSafeStr, toJson: fromDart${dartTypeSafeStr}ToGraphQL$graphqlTypeSafeStr)';
   }
 
-  return ClassProperty(dartTypeStr, alias, annotation: annotation);
+  return ClassProperty(dartTypeStr, ReCase(alias).camelCase,
+      annotation: annotation);
 }
 
 ClassProperty _selectionToClassProperty(

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -417,7 +417,7 @@ List<Definition> _extractClasses(
 
       classProperties.add(ClassProperty('String', 'resolveType',
           annotation: 'JsonKey(name: \'${schemaMap.resolveTypeField}\')',
-          override: true));
+          isOverride: true));
 
       implementations.forEach((interfaceType) {
         queue.addAll(_extractClasses(
@@ -441,7 +441,7 @@ List<Definition> _extractClasses(
               prefix: prefix,
             );
             if (cp != null) {
-              classProperties.add(cp.copyWith(override: true));
+              classProperties.add(cp.copyWith(isOverride: true));
             }
           },
         );
@@ -455,7 +455,8 @@ List<Definition> _extractClasses(
         mergeDuplicatesBy(
             classProperties.where((c) => c != null),
             (c) => c.name,
-            (old, n) => old.copyWith(override: old.override || n.override)),
+            (old, n) =>
+                old.copyWith(isOverride: old.isOverride || n.isOverride)),
         extension: classExtension,
         implementations: classImplementations,
         factoryPossibilities: factoryPossibilities.toList(),

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -413,7 +413,7 @@ List<Definition> _extractClasses(
           .map((t) => gql.getTypeByName(schema, t.name))
           .toSet();
 
-      classImplementations = implementations.map((t) => t.name);
+      classImplementations = implementations.map((t) => '$prefix${t.name}');
 
       classProperties.add(ClassProperty('String', 'resolveType',
           annotation: 'JsonKey(name: \'${schemaMap.resolveTypeField}\')',

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -176,8 +176,7 @@ ClassProperty _createClassProperty(
         'JsonKey(fromJson: fromGraphQL${graphqlTypeSafeStr}ToDart$dartTypeSafeStr, toJson: fromDart${dartTypeSafeStr}ToGraphQL$graphqlTypeSafeStr)';
   }
 
-  return ClassProperty(dartTypeStr, ReCase(alias).camelCase,
-      annotation: annotation);
+  return ClassProperty(dartTypeStr, alias, annotation: annotation);
 }
 
 ClassProperty _selectionToClassProperty(

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -413,7 +413,8 @@ List<Definition> _extractClasses(
           .map((t) => gql.getTypeByName(schema, t.name))
           .toSet();
 
-      classImplementations = implementations.map((t) => '$prefix${t.name}');
+      classImplementations =
+          implementations.map((t) => '$prefix${t.name}').toList();
 
       classProperties.add(ClassProperty('String', 'resolveType',
           annotation: 'JsonKey(name: \'${schemaMap.resolveTypeField}\')',

--- a/lib/generator/data.dart
+++ b/lib/generator/data.dart
@@ -23,22 +23,27 @@ class ClassProperty extends Equatable {
   final String name;
 
   /// If property is an override from super class.
-  final bool override;
+  final bool isOverride;
 
   /// Some other custom annotation.
   final String annotation;
 
   /// Instantiate a property (field) from a class.
-  ClassProperty(this.type, this.name, {this.override = false, this.annotation});
+  ClassProperty(this.type, this.name,
+      {this.isOverride = false, this.annotation});
 
   /// Creates a copy of [ClassProperty] without modifying the original.
   ClassProperty copyWith(
-          {String type, String name, bool override, String annotation}) =>
+          {String type, String name, bool isOverride, String annotation}) =>
       ClassProperty(type ?? this.type, name ?? this.name,
-          override: override ?? this.override,
+          isOverride: isOverride ?? this.isOverride,
           annotation: annotation ?? this.annotation);
 
-  List get props => [type, name, override, annotation];
+  @override
+  String toString() => props.toList().toString();
+
+  @override
+  List get props => [type, name, isOverride, annotation];
 }
 
 /// Define a query/mutation input parameter.
@@ -69,6 +74,9 @@ abstract class Definition extends Equatable {
   Definition(this.name)
       : assert(
             name != null && name.isNotEmpty, 'Name can\'t be null nor empty.');
+
+  @override
+  String toString() => props.toList().toString();
 
   @override
   List get props => [name];
@@ -103,6 +111,9 @@ class ClassDefinition extends Definition {
   }) : super(name);
 
   @override
+  String toString() => props.toList().toString();
+
+  @override
   List get props => [
         name,
         properties,
@@ -125,6 +136,9 @@ class EnumDefinition extends Definition {
   )   : assert(values != null && values.isNotEmpty,
             'An enum must have at least one possible value.'),
         super(name);
+
+  @override
+  String toString() => props.toList().toString();
 
   @override
   List get props => [name, values];
@@ -167,6 +181,9 @@ class QueryDefinition extends Equatable {
         );
 
   @override
+  String toString() => props.toList().toString();
+
+  @override
   List get props => [queryName, document, classes, inputs, generateHelpers];
 }
 
@@ -193,6 +210,9 @@ class LibraryDefinition extends Equatable {
     this.customImports = const [],
   }) : assert(basename != null && basename.isNotEmpty,
             'Basename must not be null or empty.');
+
+  @override
+  String toString() => props.toList().toString();
 
   @override
   List get props => [basename, queries, customParserImport, customImports];

--- a/lib/generator/print_helpers.dart
+++ b/lib/generator/print_helpers.dart
@@ -109,7 +109,7 @@ Spec classDefinitionToSpec(ClassDefinition definition) {
       ..methods.add(toJson)
       ..fields.addAll(definition.properties.map((p) {
         final annotations = <CodeExpression>[];
-        if (p.override) annotations.add(CodeExpression(Code('override')));
+        if (p.isOverride) annotations.add(CodeExpression(Code('override')));
         if (p.annotation != null) {
           annotations.add(CodeExpression(Code(p.annotation)));
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 2.0.6
+version: 2.0.7
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/test/generator/print_helpers_test.dart
+++ b/test/generator/print_helpers_test.dart
@@ -175,8 +175,9 @@ class AClass with EquatableMixin {
       final definition = ClassDefinition('AClass', [
         ClassProperty('Type', 'name'),
         ClassProperty('AnnotedProperty', 'name', annotation: 'Hey()'),
-        ClassProperty('OverridenProperty', 'name', override: true),
-        ClassProperty('AllAtOnce', 'name', override: true, annotation: 'Ho()'),
+        ClassProperty('OverridenProperty', 'name', isOverride: true),
+        ClassProperty('AllAtOnce', 'name',
+            isOverride: true, annotation: 'Ho()'),
       ]);
 
       final str = specToString(classDefinitionToSpec(definition));


### PR DESCRIPTION
- Add missing prefix to interfaces
- ~Make all class properties camelCased~

Edit: Reverted camel case class properties because, in order to make it right, we'd need to add it to `JsonKey` `name` as well. Maybe on another PR.

Fixes https://github.com/comigor/artemis/issues/30