### PR TITLE
Fragments as Mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.1.0
+- Generate fragments as mixins
+
 ## 2.0.7+1
 - README updates
 

--- a/example/graphbrainz/lib/queries/ed_sheeran.query.dart
+++ b/example/graphbrainz/lib/queries/ed_sheeran.query.dart
@@ -26,7 +26,7 @@ class Node with EquatableMixin {
   Node();
 
   factory Node.fromJson(Map<String, dynamic> json) {
-    switch (json['__typename']) {
+    switch (json['__typename'].toString()) {
       case 'Artist':
         return Artist.fromJson(json);
       default:

--- a/example/graphbrainz/lib/queries/ed_sheeran.query.g.dart
+++ b/example/graphbrainz/lib/queries/ed_sheeran.query.g.dart
@@ -53,12 +53,11 @@ Map<String, dynamic> _$ArtistToJson(Artist instance) => <String, dynamic>{
 
 LifeSpan _$LifeSpanFromJson(Map<String, dynamic> json) {
   return LifeSpan()
-    ..begin =
-        json['begin'] == null ? null : DateTime.parse(json['begin'] as String);
+    ..begin = fromGraphQLDateToDartDateTime(json['begin'] as String);
 }
 
 Map<String, dynamic> _$LifeSpanToJson(LifeSpan instance) => <String, dynamic>{
-      'begin': instance.begin?.toIso8601String(),
+      'begin': fromDartDateTimeToGraphQLDate(instance.begin),
     };
 
 SpotifyArtist _$SpotifyArtistFromJson(Map<String, dynamic> json) {

--- a/example/graphbrainz/pubspec.lock
+++ b/example/graphbrainz/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.38.2"
+    version: "0.38.5"
   args:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.0.5"
+    version: "2.0.7+1"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   build_config:
     dependency: transitive
     description:
@@ -56,21 +56,21 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.8"
+    version: "1.2.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.1"
+    version: "1.7.2"
   build_runner_core:
     dependency: transitive
     description:
@@ -84,14 +84,14 @@ packages:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.2"
+    version: "4.3.0"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.7.1"
+    version: "7.0.0"
   charcode:
     dependency: transitive
     description:
@@ -112,7 +112,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   collection:
     dependency: transitive
     description:
@@ -127,6 +127,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.3+1"
   crypto:
     dependency: transitive
     description:
@@ -147,7 +154,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.10"
+    version: "1.3.3"
   equatable:
     dependency: transitive
     description:
@@ -161,21 +168,21 @@ packages:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.9"
+    version: "0.10.11"
   front_end:
     dependency: transitive
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.24"
+    version: "0.1.27"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.7"
+    version: "1.2.0"
   gql:
     dependency: transitive
     description:
@@ -224,7 +231,7 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0+2"
+    version: "0.14.0+3"
   http:
     dependency: "direct main"
     description:
@@ -280,14 +287,14 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.3"
   kernel:
     dependency: transitive
     description:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.24"
+    version: "0.3.27"
   logging:
     dependency: transitive
     description:
@@ -301,14 +308,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.5"
+    version: "0.12.6"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.8"
   mime:
     dependency: transitive
     description:
@@ -323,6 +330,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  node_interop:
+    dependency: transitive
+    description:
+      name: node_interop
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
+  node_io:
+    dependency: transitive
+    description:
+      name: node_io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1+2"
   node_preamble:
     dependency: transitive
     description:
@@ -385,7 +406,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.2+1"
   recase:
     dependency: transitive
     description:
@@ -427,7 +448,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.4+4"
+    version: "0.9.4+6"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -469,7 +490,7 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.19"
+    version: "0.0.20"
   string_scanner:
     dependency: transitive
     description:
@@ -490,21 +511,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.10"
+    version: "1.9.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.7"
+    version: "0.2.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.9+1"
+    version: "0.2.15"
   timing:
     dependency: transitive
     description:
@@ -525,7 +546,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.1"
   watcher:
     dependency: transitive
     description:
@@ -539,7 +560,7 @@ packages:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.15"
+    version: "1.1.0"
   yaml:
     dependency: transitive
     description:
@@ -548,4 +569,4 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.3.0 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"

--- a/example/graphbrainz/pubspec.lock
+++ b/example/graphbrainz/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.0.7+1"
+    version: "2.1.0"
   async:
     dependency: transitive
     description:

--- a/example/pokemon/build.yaml
+++ b/example/pokemon/build.yaml
@@ -14,3 +14,6 @@ targets:
             - schema: pokemon.schema.json
               queries_glob: graphql/big_query.query.graphql
               output: lib/graphql/big_query.dart
+            - schema: pokemon.schema.json
+              queries_glob: graphql/fragment_query.query.graphql
+              output: lib/graphql/fragment_query.dart

--- a/example/pokemon/graphql/fragment_query.query.graphql
+++ b/example/pokemon/graphql/fragment_query.query.graphql
@@ -1,0 +1,17 @@
+fragment PokemonParts on Pokemon {
+  number
+  name
+  types
+}
+
+query fragmentQuery($quantity: Int!) {
+  charmander: pokemon(name: "Charmander") {
+    ...PokemonParts
+  }
+  pokemons(first: $quantity) {
+    ...PokemonParts
+    evolutions: evolutions {
+      ...PokemonParts
+    }
+  }
+}

--- a/example/pokemon/lib/graphql/fragment_query.dart
+++ b/example/pokemon/lib/graphql/fragment_query.dart
@@ -1,0 +1,177 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+import 'package:artemis/artemis.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
+import 'package:gql/ast.dart';
+part 'fragment_query.g.dart';
+
+mixin PokemonPartsMixin {
+  String number;
+  String name;
+  List<String> types;
+}
+
+@JsonSerializable(explicitToJson: true)
+class FragmentQuery with EquatableMixin {
+  FragmentQuery();
+
+  factory FragmentQuery.fromJson(Map<String, dynamic> json) =>
+      _$FragmentQueryFromJson(json);
+
+  Charmander charmander;
+
+  List<Pokemon> pokemons;
+
+  @override
+  List<Object> get props => [charmander, pokemons];
+  Map<String, dynamic> toJson() => _$FragmentQueryToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class Charmander with EquatableMixin, PokemonPartsMixin {
+  Charmander();
+
+  factory Charmander.fromJson(Map<String, dynamic> json) =>
+      _$CharmanderFromJson(json);
+
+  @override
+  List<Object> get props => [number, name, types];
+  Map<String, dynamic> toJson() => _$CharmanderToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class Pokemon with EquatableMixin, PokemonPartsMixin {
+  Pokemon();
+
+  factory Pokemon.fromJson(Map<String, dynamic> json) =>
+      _$PokemonFromJson(json);
+
+  List<Evolutions> evolutions;
+
+  @override
+  List<Object> get props => [number, name, types, evolutions];
+  Map<String, dynamic> toJson() => _$PokemonToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class Evolutions with EquatableMixin, PokemonPartsMixin {
+  Evolutions();
+
+  factory Evolutions.fromJson(Map<String, dynamic> json) =>
+      _$EvolutionsFromJson(json);
+
+  @override
+  List<Object> get props => [number, name, types];
+  Map<String, dynamic> toJson() => _$EvolutionsToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class FragmentQueryArguments extends JsonSerializable with EquatableMixin {
+  FragmentQueryArguments({this.quantity});
+
+  factory FragmentQueryArguments.fromJson(Map<String, dynamic> json) =>
+      _$FragmentQueryArgumentsFromJson(json);
+
+  final int quantity;
+
+  @override
+  List<Object> get props => [quantity];
+  Map<String, dynamic> toJson() => _$FragmentQueryArgumentsToJson(this);
+}
+
+class FragmentQueryQuery
+    extends GraphQLQuery<FragmentQuery, FragmentQueryArguments> {
+  FragmentQueryQuery({this.variables});
+
+  @override
+  final DocumentNode document = DocumentNode(definitions: [
+    FragmentDefinitionNode(
+        name: NameNode(value: 'PokemonParts'),
+        typeCondition: TypeConditionNode(
+            on: NamedTypeNode(
+                name: NameNode(value: 'Pokemon'), isNonNull: false)),
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+              name: NameNode(value: 'number'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: null),
+          FieldNode(
+              name: NameNode(value: 'name'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: null),
+          FieldNode(
+              name: NameNode(value: 'types'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: null)
+        ])),
+    OperationDefinitionNode(
+        type: OperationType.query,
+        name: NameNode(value: 'fragmentQuery'),
+        variableDefinitions: [
+          VariableDefinitionNode(
+              variable: VariableNode(name: NameNode(value: 'quantity')),
+              type:
+                  NamedTypeNode(name: NameNode(value: 'Int'), isNonNull: true),
+              defaultValue: DefaultValueNode(value: null),
+              directives: [])
+        ],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+              name: NameNode(value: 'pokemon'),
+              alias: NameNode(value: 'charmander'),
+              arguments: [
+                ArgumentNode(
+                    name: NameNode(value: 'name'),
+                    value: StringValueNode(value: 'Charmander', isBlock: false))
+              ],
+              directives: [],
+              selectionSet: SelectionSetNode(selections: [
+                FragmentSpreadNode(
+                    name: NameNode(value: 'PokemonParts'), directives: [])
+              ])),
+          FieldNode(
+              name: NameNode(value: 'pokemons'),
+              alias: null,
+              arguments: [
+                ArgumentNode(
+                    name: NameNode(value: 'first'),
+                    value: VariableNode(name: NameNode(value: 'quantity')))
+              ],
+              directives: [],
+              selectionSet: SelectionSetNode(selections: [
+                FragmentSpreadNode(
+                    name: NameNode(value: 'PokemonParts'), directives: []),
+                FieldNode(
+                    name: NameNode(value: 'evolutions'),
+                    alias: NameNode(value: 'evolutions'),
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FragmentSpreadNode(
+                          name: NameNode(value: 'PokemonParts'), directives: [])
+                    ]))
+              ]))
+        ]))
+  ]);
+
+  @override
+  final String operationName = 'fragmentQuery';
+
+  @override
+  final FragmentQueryArguments variables;
+
+  @override
+  List<Object> get props => [document, operationName, variables];
+  @override
+  FragmentQuery parse(Map<String, dynamic> json) =>
+      FragmentQuery.fromJson(json);
+}

--- a/example/pokemon/lib/graphql/fragment_query.g.dart
+++ b/example/pokemon/lib/graphql/fragment_query.g.dart
@@ -1,0 +1,83 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'fragment_query.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FragmentQuery _$FragmentQueryFromJson(Map<String, dynamic> json) {
+  return FragmentQuery()
+    ..charmander = json['charmander'] == null
+        ? null
+        : Charmander.fromJson(json['charmander'] as Map<String, dynamic>)
+    ..pokemons = (json['pokemons'] as List)
+        ?.map((e) =>
+            e == null ? null : Pokemon.fromJson(e as Map<String, dynamic>))
+        ?.toList();
+}
+
+Map<String, dynamic> _$FragmentQueryToJson(FragmentQuery instance) =>
+    <String, dynamic>{
+      'charmander': instance.charmander?.toJson(),
+      'pokemons': instance.pokemons?.map((e) => e?.toJson())?.toList(),
+    };
+
+Charmander _$CharmanderFromJson(Map<String, dynamic> json) {
+  return Charmander()
+    ..number = json['number'] as String
+    ..name = json['name'] as String
+    ..types = (json['types'] as List)?.map((e) => e as String)?.toList();
+}
+
+Map<String, dynamic> _$CharmanderToJson(Charmander instance) =>
+    <String, dynamic>{
+      'number': instance.number,
+      'name': instance.name,
+      'types': instance.types,
+    };
+
+Pokemon _$PokemonFromJson(Map<String, dynamic> json) {
+  return Pokemon()
+    ..number = json['number'] as String
+    ..name = json['name'] as String
+    ..types = (json['types'] as List)?.map((e) => e as String)?.toList()
+    ..evolutions = (json['evolutions'] as List)
+        ?.map((e) =>
+            e == null ? null : Evolutions.fromJson(e as Map<String, dynamic>))
+        ?.toList();
+}
+
+Map<String, dynamic> _$PokemonToJson(Pokemon instance) => <String, dynamic>{
+      'number': instance.number,
+      'name': instance.name,
+      'types': instance.types,
+      'evolutions': instance.evolutions?.map((e) => e?.toJson())?.toList(),
+    };
+
+Evolutions _$EvolutionsFromJson(Map<String, dynamic> json) {
+  return Evolutions()
+    ..number = json['number'] as String
+    ..name = json['name'] as String
+    ..types = (json['types'] as List)?.map((e) => e as String)?.toList();
+}
+
+Map<String, dynamic> _$EvolutionsToJson(Evolutions instance) =>
+    <String, dynamic>{
+      'number': instance.number,
+      'name': instance.name,
+      'types': instance.types,
+    };
+
+FragmentQueryArguments _$FragmentQueryArgumentsFromJson(
+    Map<String, dynamic> json) {
+  return FragmentQueryArguments(
+    quantity: json['quantity'] as int,
+  );
+}
+
+Map<String, dynamic> _$FragmentQueryArgumentsToJson(
+        FragmentQueryArguments instance) =>
+    <String, dynamic>{
+      'quantity': instance.quantity,
+    };

--- a/example/pokemon/pubspec.lock
+++ b/example/pokemon/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.38.2"
+    version: "0.38.5"
   args:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.0.5"
+    version: "2.0.7+1"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   build_config:
     dependency: transitive
     description:
@@ -56,21 +56,21 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.8"
+    version: "1.2.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.1"
+    version: "1.7.2"
   build_runner_core:
     dependency: transitive
     description:
@@ -84,14 +84,14 @@ packages:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.2"
+    version: "4.3.0"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.7.1"
+    version: "7.0.0"
   charcode:
     dependency: transitive
     description:
@@ -112,7 +112,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   collection:
     dependency: transitive
     description:
@@ -127,6 +127,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.3+1"
   crypto:
     dependency: transitive
     description:
@@ -147,7 +154,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.10"
+    version: "1.3.3"
   equatable:
     dependency: transitive
     description:
@@ -161,21 +168,21 @@ packages:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.9"
+    version: "0.10.11"
   front_end:
     dependency: transitive
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.24"
+    version: "0.1.27"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.7"
+    version: "1.2.0"
   gql:
     dependency: transitive
     description:
@@ -224,7 +231,7 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0+2"
+    version: "0.14.0+3"
   http:
     dependency: "direct main"
     description:
@@ -273,14 +280,14 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.3"
   kernel:
     dependency: transitive
     description:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.24"
+    version: "0.3.27"
   logging:
     dependency: transitive
     description:
@@ -294,14 +301,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.5"
+    version: "0.12.6"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.8"
   mime:
     dependency: transitive
     description:
@@ -316,6 +323,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  node_interop:
+    dependency: transitive
+    description:
+      name: node_interop
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
+  node_io:
+    dependency: transitive
+    description:
+      name: node_io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1+2"
   node_preamble:
     dependency: transitive
     description:
@@ -378,7 +399,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.2+1"
   recase:
     dependency: transitive
     description:
@@ -420,7 +441,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.4+4"
+    version: "0.9.4+6"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -462,7 +483,7 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.19"
+    version: "0.0.20"
   string_scanner:
     dependency: transitive
     description:
@@ -483,21 +504,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.10"
+    version: "1.9.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.7"
+    version: "0.2.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.9+1"
+    version: "0.2.15"
   timing:
     dependency: transitive
     description:
@@ -518,7 +539,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.1"
   watcher:
     dependency: transitive
     description:
@@ -532,7 +553,7 @@ packages:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.15"
+    version: "1.1.0"
   yaml:
     dependency: transitive
     description:
@@ -541,4 +562,4 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.3.0 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"

--- a/example/pokemon/pubspec.lock
+++ b/example/pokemon/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.0.7+1"
+    version: "2.1.0"
   async:
     dependency: transitive
     description:

--- a/lib/generator/data.dart
+++ b/lib/generator/data.dart
@@ -82,7 +82,7 @@ abstract class Definition extends Equatable {
   List get props => [name];
 }
 
-/// Define a Dart class parsed from GraphQL schema.
+/// Define a Dart class parsed from GraphQL type.
 class ClassDefinition extends Definition {
   /// The properties (fields) of the class.
   final Iterable<ClassProperty> properties;
@@ -92,6 +92,9 @@ class ClassDefinition extends Definition {
 
   /// The types this class implements.
   final Iterable<String> implementations;
+
+  /// The types this class mixins.
+  final Iterable<FragmentClassDefinition> mixins;
 
   /// The types possibilities the class implements, if it's part of an union
   /// type or interface.
@@ -106,6 +109,7 @@ class ClassDefinition extends Definition {
     this.properties, {
     this.extension,
     this.implementations = const [],
+    this.mixins = const [],
     this.factoryPossibilities = const [],
     this.resolveTypeField = '__resolveType',
   }) : super(name);
@@ -119,9 +123,28 @@ class ClassDefinition extends Definition {
         properties,
         extension,
         implementations,
+        mixins,
         factoryPossibilities,
         resolveTypeField,
       ];
+}
+
+/// Define a Dart class parsed from GraphQL fragment.
+class FragmentClassDefinition extends Definition {
+  /// The properties (fields) of the class.
+  final Iterable<ClassProperty> properties;
+
+  /// Instantiate a fragment class definition.
+  FragmentClassDefinition(
+    String name,
+    this.properties,
+  ) : super(name);
+
+  @override
+  String toString() => props.toList().toString();
+
+  @override
+  List get props => [name, properties];
 }
 
 /// Define a Dart enum parsed from GraphQL schema.

--- a/lib/generator/print_helpers.dart
+++ b/lib/generator/print_helpers.dart
@@ -13,7 +13,8 @@ Spec enumDefinitionToSpec(EnumDefinition definition) =>
 
 String _fromJsonBody(ClassDefinition definition) {
   final buffer = StringBuffer();
-  buffer.writeln('''switch (json['${definition.resolveTypeField}']) {''');
+  buffer.writeln(
+      '''switch (json['${definition.resolveTypeField}'].toString()) {''');
 
   for (final p in definition.factoryPossibilities) {
     buffer.writeln('''      case '$p':

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 2.0.7+1
+version: 2.1.0
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/test/generator/print_helpers_test.dart
+++ b/test/generator/print_helpers_test.dart
@@ -55,6 +55,36 @@ void main() {
 ''');
     });
   });
+  group('On printCustomFragmentClass', () {
+    test('It will throw if name is null or empty.', () {
+      expect(
+          () =>
+              fragmentClassDefinitionToSpec(FragmentClassDefinition(null, [])),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(
+          () => fragmentClassDefinitionToSpec(FragmentClassDefinition('', [])),
+          throwsA(TypeMatcher<AssertionError>()));
+    });
+
+    test('It will generate an Mixins declarations.', () {
+      final definition = FragmentClassDefinition('FragmentMixin', [
+        ClassProperty('Type', 'name'),
+        ClassProperty('Type', 'name', isOverride: true),
+        ClassProperty('Type', 'name', annotation: 'Test'),
+      ]);
+
+      final str = specToString(fragmentClassDefinitionToSpec(definition));
+
+      expect(str, '''mixin FragmentMixin {
+  Type name;
+  @override
+  Type name;
+  @Test
+  Type name;
+}
+''');
+    });
+  });
 
   group('On printCustomClass', () {
     test('It will throw if name is null or empty.', () {
@@ -202,6 +232,30 @@ class AClass with EquatableMixin {
 
   @override
   List<Object> get props => [name, name, name, name];
+  Map<String, dynamic> toJson() => _\$AClassToJson(this);
+}
+''');
+    });
+
+    test(
+        'Mixins can be included and its properties will be considered on props getter',
+        () {
+      final definition = ClassDefinition('AClass', [], mixins: [
+        FragmentClassDefinition('FragmentMixin', [
+          ClassProperty('Type', 'name'),
+        ]),
+      ]);
+
+      final str = specToString(classDefinitionToSpec(definition));
+
+      expect(str, '''@JsonSerializable(explicitToJson: true)
+class AClass with EquatableMixin, FragmentMixin {
+  AClass();
+
+  factory AClass.fromJson(Map<String, dynamic> json) => _\$AClassFromJson(json);
+
+  @override
+  List<Object> get props => [name];
   Map<String, dynamic> toJson() => _\$AClassToJson(this);
 }
 ''');

--- a/test/generator/print_helpers_test.dart
+++ b/test/generator/print_helpers_test.dart
@@ -118,7 +118,7 @@ class AClass with EquatableMixin {
   AClass();
 
   factory AClass.fromJson(Map<String, dynamic> json) {
-    switch (json['__resolveType']) {
+    switch (json['__resolveType'].toString()) {
       case 'ASubClass':
         return ASubClass.fromJson(json);
       case 'BSubClass':

--- a/test/query_generator/query_generator_test.dart
+++ b/test/query_generator/query_generator_test.dart
@@ -1238,5 +1238,98 @@ class PascalCasingQuery with EquatableMixin {
 ''',
       });
     });
+
+    test('Fragments will have their own classes', () async {
+      final GraphQLQueryBuilder anotherBuilder =
+          graphQLQueryBuilder(BuilderOptions({
+        'generate_helpers': false,
+        'schema_mapping': [
+          {
+            'schema': 'api.schema.json',
+            'queries_glob': '**.graphql',
+            'output': 'lib/some_query.dart',
+          }
+        ]
+      }));
+      final GraphQLSchema schema = GraphQLSchema(
+          queryType:
+              GraphQLType(name: 'SomeObject', kind: GraphQLTypeKind.OBJECT),
+          types: [
+            GraphQLType(name: 'String', kind: GraphQLTypeKind.SCALAR),
+            GraphQLType(name: 'Int', kind: GraphQLTypeKind.SCALAR),
+            GraphQLType(
+                name: 'SomeObject',
+                kind: GraphQLTypeKind.OBJECT,
+                fields: [
+                  GraphQLField(
+                      name: 's',
+                      type: GraphQLType(
+                          name: 'String', kind: GraphQLTypeKind.SCALAR)),
+                  GraphQLField(
+                      name: 'i',
+                      type: GraphQLType(
+                          name: 'Int', kind: GraphQLTypeKind.SCALAR)),
+                ]),
+          ]);
+
+      anotherBuilder.onBuild = expectAsync1((definition) {
+        expect(
+          definition,
+          LibraryDefinition(
+            'some_query',
+            queries: [
+              QueryDefinition(
+                'some_query',
+                parseString(
+                    'fragment myFragment on SomeQuery { s, i }\nquery some_query { ...myFragment }'),
+                classes: [
+                  ClassDefinition('SomeQuery', [], mixins: [
+                    FragmentClassDefinition('MyFragmentMixin', [
+                      ClassProperty('String', 's'),
+                      ClassProperty('int', 'i'),
+                    ]),
+                  ]),
+                  FragmentClassDefinition('MyFragmentMixin', [
+                    ClassProperty('String', 's'),
+                    ClassProperty('int', 'i'),
+                  ]),
+                ],
+              ),
+            ],
+          ),
+        );
+      }, count: 1);
+
+      await testBuilder(anotherBuilder, {
+        'a|api.schema.json': jsonFromSchema(schema),
+        'a|some_query.query.graphql':
+            'fragment myFragment on SomeQuery { s, i }\nquery some_query { ...myFragment }',
+      }, outputs: {
+        'a|lib/some_query.dart': '''// GENERATED CODE - DO NOT MODIFY BY HAND
+
+import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
+import 'package:gql/ast.dart';
+part 'some_query.g.dart';
+
+mixin MyFragmentMixin {
+  String s;
+  int i;
+}
+
+@JsonSerializable(explicitToJson: true)
+class SomeQuery with EquatableMixin, MyFragmentMixin {
+  SomeQuery();
+
+  factory SomeQuery.fromJson(Map<String, dynamic> json) =>
+      _\$SomeQueryFromJson(json);
+
+  @override
+  List<Object> get props => [s, i];
+  Map<String, dynamic> toJson() => _\$SomeQueryToJson(this);
+}
+''',
+      });
+    });
   });
 }


### PR DESCRIPTION
Following https://github.com/comigor/artemis/issues/52, it seemed to be a good idea to extract fragments as mixins to easily reuse them through other types.

This would be even more useful, for instance, when concatenating multiple input files (see https://github.com/comigor/artemis/issues/49).