### PR TITLE
fix: add prefix to enum type definition

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,4 +1,4 @@
-on: push
+on: [push, pull_request]
 
 name: CI
 

--- a/.github/workflows/analyzer.yml
+++ b/.github/workflows/analyzer.yml
@@ -2,7 +2,6 @@ name: Package analyzer
 on: [push, pull_request]
 
 jobs:
-
   package-analysis:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.1.4
+- Add missing prefix to generated enums
+
 ## 2.1.3
 - Bump equatable/gql suite, refine GitHub actions
 

--- a/example/graphbrainz/pubspec.lock
+++ b/example/graphbrainz/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.1.3"
+    version: "2.1.4"
   async:
     dependency: transitive
     description:

--- a/example/pokemon/pubspec.lock
+++ b/example/pokemon/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.1.3"
+    version: "2.1.4"
   async:
     dependency: transitive
     description:

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -270,7 +270,7 @@ List<Definition> _extractClasses(
   if (currentType.kind == GraphQLTypeKind.ENUM) {
     return [
       EnumDefinition(
-        currentType.name,
+        prefix + currentType.name,
         currentType.enumValues.map((eV) => eV.name).toList(),
       ),
     ];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 2.1.3
+version: 2.1.4
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/test/query_generator/query_generator_test.dart
+++ b/test/query_generator/query_generator_test.dart
@@ -977,6 +977,13 @@ class SomeQuery with EquatableMixin {
           queryType: GraphQLType(name: 'Query', kind: GraphQLTypeKind.OBJECT),
           types: [
             GraphQLType(name: 'String', kind: GraphQLTypeKind.SCALAR),
+            GraphQLType(
+                name: 'MyEnum',
+                kind: GraphQLTypeKind.ENUM,
+                enumValues: [
+                  GraphQLEnumValue(name: 'value1'),
+                  GraphQLEnumValue(name: 'value2'),
+                ]),
             GraphQLType(name: 'Query', kind: GraphQLTypeKind.OBJECT, fields: [
               GraphQLField(
                   name: 's',
@@ -986,6 +993,10 @@ class SomeQuery with EquatableMixin {
                   name: 'o',
                   type: GraphQLType(
                       name: 'SomeObject', kind: GraphQLTypeKind.OBJECT)),
+              GraphQLField(
+                  name: 'e',
+                  type:
+                      GraphQLType(name: 'MyEnum', kind: GraphQLTypeKind.ENUM)),
             ]),
             GraphQLType(
                 name: 'SomeObject',
@@ -1039,6 +1050,7 @@ class SomeQuery with EquatableMixin {
               str
             }
           }
+          e
         }
         ''';
 
@@ -1056,7 +1068,8 @@ class SomeQuery with EquatableMixin {
                       'SomeQuery',
                       [
                         ClassProperty('String', 's'),
-                        ClassProperty('SomeQuerySomeObject', 'o')
+                        ClassProperty('SomeQuerySomeObject', 'o'),
+                        ClassProperty('SomeQueryMyEnum', 'e')
                       ],
                       prefix: 'SomeQuery'),
                   ClassDefinition(
@@ -1081,6 +1094,7 @@ class SomeQuery with EquatableMixin {
                             annotation: 'JsonKey(name: \'__resolveType\')')
                       ],
                       prefix: 'SomeQuery'),
+                  EnumDefinition('SomeQueryMyEnum', ['value1', 'value2']),
                 ],
               ),
             ],
@@ -1110,8 +1124,10 @@ class SomeQuery with EquatableMixin {
 
   SomeQuerySomeObject o;
 
+  SomeQueryMyEnum e;
+
   @override
-  List<Object> get props => [s, o];
+  List<Object> get props => [s, o, e];
   Map<String, dynamic> toJson() => _\$SomeQueryToJson(this);
 }
 
@@ -1165,6 +1181,11 @@ class SomeQueryAInterface with EquatableMixin {
   @override
   List<Object> get props => [st, resolveType];
   Map<String, dynamic> toJson() => _\$SomeQueryAInterfaceToJson(this);
+}
+
+enum SomeQueryMyEnum {
+  value1,
+  value2,
 }
 ''',
       });


### PR DESCRIPTION
Seems enum type has the user-specified prefix as class property, while has no prefix as definition.

Tested query (GitHub API v4):

```graphql
{
  node(id: "") {
    ... on Commit {
      status {
        state
      }
    }
  }
}
```

The `state` in this query is an enum.