### PR TITLE
Sharing fragments

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - run: |
-        go get -u github.com/itchyny/gojq/cmd/gojq
+        GO111MODULE=on go get -u github.com/itchyny/gojq/cmd/gojq@d24ecb5d89a9eee8b4cd2071bdff7585a8b44f0e
         cd "$GITHUB_WORKSPACE"
     - name: Check if version on pubspec.yaml was changed and if there's an entry for this new version on CHANGELOG
       run: |

--- a/.github/workflows/analyzer.yml
+++ b/.github/workflows/analyzer.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 jobs:
   package-analysis:
+    if: github.actor == 'comigor'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.2.0
+- Share fragments between queries and schemas (see `fragments_glob`) [#65](https://github.com/comigor/artemis/pull/65)
+
 ## 2.1.4
 - Add missing prefix to generated enums
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ targets:
 | `custom_parser_import` | `null` | Import path to the file implementing coercer functions for custom scalars. See [Custom scalars](#custom-scalars). |
 | `scalar_mapping` | `[]` | Mapping of GraphQL and Dart types. See [Custom scalars](#custom-scalars). |
 | `schema_mapping` | `[]` | Mapping of queries and which schemas they will use for code generation. See [Schema mapping](#schema-mapping). |
+| `fragments_glob` | `null` | Import path to the file implementing fragments which is mapping to all queries in schema_mapping. If it's assigned, fragments is defined in schemap_mapping will be ignored. |
 
 It's important to remember that, by default, [build](https://github.com/dart-lang/build) will follow [Dart's package layout conventions](https://dart.dev/tools/pub/package-layout), meaning that only some folders will be considered to parse the input files. So, if you want to reference files from a folder other than `lib/`, make sure you've included it on `sources`:
 ```yaml

--- a/example/graphbrainz/pubspec.lock
+++ b/example/graphbrainz/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.1.4"
+    version: "2.2.0"
   async:
     dependency: transitive
     description:

--- a/example/pokemon/build.yaml
+++ b/example/pokemon/build.yaml
@@ -7,6 +7,7 @@ targets:
     builders:
       artemis:
         options:
+          fragments_glob: graphql/**.fragment.graphql
           schema_mapping:
             - schema: pokemon.schema.json
               queries_glob: graphql/simple_query.query.graphql
@@ -17,3 +18,6 @@ targets:
             - schema: pokemon.schema.json
               queries_glob: graphql/fragment_query.query.graphql
               output: lib/graphql/fragment_query.dart
+            - schema: pokemon.schema.json
+              queries_glob: graphql/fragments_glob.query.graphql
+              output: lib/graphql/fragments_glob.dart

--- a/example/pokemon/graphql/fragment_query.query.graphql
+++ b/example/pokemon/graphql/fragment_query.query.graphql
@@ -1,9 +1,3 @@
-fragment PokemonParts on Pokemon {
-  number
-  name
-  types
-}
-
 query fragmentQuery($quantity: Int!) {
   charmander: pokemon(name: "Charmander") {
     ...PokemonParts

--- a/example/pokemon/graphql/fragments_glob.fragment.graphql
+++ b/example/pokemon/graphql/fragments_glob.fragment.graphql
@@ -1,0 +1,30 @@
+fragment Pokemon on Pokemon {
+  		id
+      weight {
+        ...weight
+      }
+      attacks {
+        ...pokemonAttack
+      }
+    
+}
+
+fragment PokemonParts on Pokemon {
+  number
+  name
+  types
+}
+
+fragment weight on PokemonDimension {
+  	minimum
+}
+
+fragment pokemonAttack on PokemonAttack {
+  special {
+    ...attack
+  }
+}
+
+fragment attack on Attack {
+  name
+}

--- a/example/pokemon/graphql/fragments_glob.query.graphql
+++ b/example/pokemon/graphql/fragments_glob.query.graphql
@@ -1,0 +1,8 @@
+{
+  pokemon(name: "Pikachu") {
+    ...Pokemon
+    evolutions {
+      ...Pokemon
+    }
+  }
+}

--- a/example/pokemon/lib/graphql/fragment_query.dart
+++ b/example/pokemon/lib/graphql/fragment_query.dart
@@ -86,32 +86,6 @@ class FragmentQueryQuery
 
   @override
   final DocumentNode document = DocumentNode(definitions: [
-    FragmentDefinitionNode(
-        name: NameNode(value: 'PokemonParts'),
-        typeCondition: TypeConditionNode(
-            on: NamedTypeNode(
-                name: NameNode(value: 'Pokemon'), isNonNull: false)),
-        directives: [],
-        selectionSet: SelectionSetNode(selections: [
-          FieldNode(
-              name: NameNode(value: 'number'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null),
-          FieldNode(
-              name: NameNode(value: 'name'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null),
-          FieldNode(
-              name: NameNode(value: 'types'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null)
-        ])),
     OperationDefinitionNode(
         type: OperationType.query,
         name: NameNode(value: 'fragmentQuery'),
@@ -160,6 +134,32 @@ class FragmentQueryQuery
                           name: NameNode(value: 'PokemonParts'), directives: [])
                     ]))
               ]))
+        ])),
+    FragmentDefinitionNode(
+        name: NameNode(value: 'PokemonParts'),
+        typeCondition: TypeConditionNode(
+            on: NamedTypeNode(
+                name: NameNode(value: 'Pokemon'), isNonNull: false)),
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+              name: NameNode(value: 'number'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: null),
+          FieldNode(
+              name: NameNode(value: 'name'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: null),
+          FieldNode(
+              name: NameNode(value: 'types'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: null)
         ]))
   ]);
 

--- a/example/pokemon/lib/graphql/fragments_glob.dart
+++ b/example/pokemon/lib/graphql/fragments_glob.dart
@@ -1,0 +1,208 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+import 'package:artemis/artemis.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
+import 'package:gql/ast.dart';
+part 'fragments_glob.g.dart';
+
+mixin WeightMixin {
+  String minimum;
+}
+mixin AttackMixin {
+  String name;
+}
+mixin PokemonAttackMixin {
+  List<Attack> special;
+}
+mixin PokemonMixin {
+  String id;
+  PokemonDimension weight;
+  PokemonAttack attacks;
+}
+
+@JsonSerializable(explicitToJson: true)
+class FragmentsGlob with EquatableMixin {
+  FragmentsGlob();
+
+  factory FragmentsGlob.fromJson(Map<String, dynamic> json) =>
+      _$FragmentsGlobFromJson(json);
+
+  Pokemon pokemon;
+
+  @override
+  List<Object> get props => [pokemon];
+  Map<String, dynamic> toJson() => _$FragmentsGlobToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class Pokemon with EquatableMixin, PokemonMixin {
+  Pokemon();
+
+  factory Pokemon.fromJson(Map<String, dynamic> json) =>
+      _$PokemonFromJson(json);
+
+  List<Pokemon> evolutions;
+
+  @override
+  List<Object> get props => [id, weight, attacks, evolutions];
+  Map<String, dynamic> toJson() => _$PokemonToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class PokemonDimension with EquatableMixin, WeightMixin {
+  PokemonDimension();
+
+  factory PokemonDimension.fromJson(Map<String, dynamic> json) =>
+      _$PokemonDimensionFromJson(json);
+
+  @override
+  List<Object> get props => [minimum];
+  Map<String, dynamic> toJson() => _$PokemonDimensionToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class PokemonAttack with EquatableMixin, PokemonAttackMixin {
+  PokemonAttack();
+
+  factory PokemonAttack.fromJson(Map<String, dynamic> json) =>
+      _$PokemonAttackFromJson(json);
+
+  @override
+  List<Object> get props => [special];
+  Map<String, dynamic> toJson() => _$PokemonAttackToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class Attack with EquatableMixin, AttackMixin {
+  Attack();
+
+  factory Attack.fromJson(Map<String, dynamic> json) => _$AttackFromJson(json);
+
+  @override
+  List<Object> get props => [name];
+  Map<String, dynamic> toJson() => _$AttackToJson(this);
+}
+
+class FragmentsGlobQuery extends GraphQLQuery<FragmentsGlob, JsonSerializable> {
+  FragmentsGlobQuery();
+
+  @override
+  final DocumentNode document = DocumentNode(definitions: [
+    OperationDefinitionNode(
+        type: OperationType.query,
+        name: null,
+        variableDefinitions: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+              name: NameNode(value: 'pokemon'),
+              alias: null,
+              arguments: [
+                ArgumentNode(
+                    name: NameNode(value: 'name'),
+                    value: StringValueNode(value: 'Pikachu', isBlock: false))
+              ],
+              directives: [],
+              selectionSet: SelectionSetNode(selections: [
+                FragmentSpreadNode(
+                    name: NameNode(value: 'Pokemon'), directives: []),
+                FieldNode(
+                    name: NameNode(value: 'evolutions'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FragmentSpreadNode(
+                          name: NameNode(value: 'Pokemon'), directives: [])
+                    ]))
+              ]))
+        ])),
+    FragmentDefinitionNode(
+        name: NameNode(value: 'Pokemon'),
+        typeCondition: TypeConditionNode(
+            on: NamedTypeNode(
+                name: NameNode(value: 'Pokemon'), isNonNull: false)),
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+              name: NameNode(value: 'id'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: null),
+          FieldNode(
+              name: NameNode(value: 'weight'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: SelectionSetNode(selections: [
+                FragmentSpreadNode(
+                    name: NameNode(value: 'weight'), directives: [])
+              ])),
+          FieldNode(
+              name: NameNode(value: 'attacks'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: SelectionSetNode(selections: [
+                FragmentSpreadNode(
+                    name: NameNode(value: 'pokemonAttack'), directives: [])
+              ]))
+        ])),
+    FragmentDefinitionNode(
+        name: NameNode(value: 'weight'),
+        typeCondition: TypeConditionNode(
+            on: NamedTypeNode(
+                name: NameNode(value: 'PokemonDimension'), isNonNull: false)),
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+              name: NameNode(value: 'minimum'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: null)
+        ])),
+    FragmentDefinitionNode(
+        name: NameNode(value: 'pokemonAttack'),
+        typeCondition: TypeConditionNode(
+            on: NamedTypeNode(
+                name: NameNode(value: 'PokemonAttack'), isNonNull: false)),
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+              name: NameNode(value: 'special'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: SelectionSetNode(selections: [
+                FragmentSpreadNode(
+                    name: NameNode(value: 'attack'), directives: [])
+              ]))
+        ])),
+    FragmentDefinitionNode(
+        name: NameNode(value: 'attack'),
+        typeCondition: TypeConditionNode(
+            on: NamedTypeNode(
+                name: NameNode(value: 'Attack'), isNonNull: false)),
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+              name: NameNode(value: 'name'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: null)
+        ]))
+  ]);
+
+  @override
+  final String operationName = 'fragments_glob';
+
+  @override
+  List<Object> get props => [document, operationName];
+  @override
+  FragmentsGlob parse(Map<String, dynamic> json) =>
+      FragmentsGlob.fromJson(json);
+}

--- a/example/pokemon/lib/graphql/fragments_glob.g.dart
+++ b/example/pokemon/lib/graphql/fragments_glob.g.dart
@@ -1,0 +1,71 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'fragments_glob.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FragmentsGlob _$FragmentsGlobFromJson(Map<String, dynamic> json) {
+  return FragmentsGlob()
+    ..pokemon = json['pokemon'] == null
+        ? null
+        : Pokemon.fromJson(json['pokemon'] as Map<String, dynamic>);
+}
+
+Map<String, dynamic> _$FragmentsGlobToJson(FragmentsGlob instance) =>
+    <String, dynamic>{
+      'pokemon': instance.pokemon?.toJson(),
+    };
+
+Pokemon _$PokemonFromJson(Map<String, dynamic> json) {
+  return Pokemon()
+    ..id = json['id'] as String
+    ..weight = json['weight'] == null
+        ? null
+        : PokemonDimension.fromJson(json['weight'] as Map<String, dynamic>)
+    ..attacks = json['attacks'] == null
+        ? null
+        : PokemonAttack.fromJson(json['attacks'] as Map<String, dynamic>)
+    ..evolutions = (json['evolutions'] as List)
+        ?.map((e) =>
+            e == null ? null : Pokemon.fromJson(e as Map<String, dynamic>))
+        ?.toList();
+}
+
+Map<String, dynamic> _$PokemonToJson(Pokemon instance) => <String, dynamic>{
+      'id': instance.id,
+      'weight': instance.weight?.toJson(),
+      'attacks': instance.attacks?.toJson(),
+      'evolutions': instance.evolutions?.map((e) => e?.toJson())?.toList(),
+    };
+
+PokemonDimension _$PokemonDimensionFromJson(Map<String, dynamic> json) {
+  return PokemonDimension()..minimum = json['minimum'] as String;
+}
+
+Map<String, dynamic> _$PokemonDimensionToJson(PokemonDimension instance) =>
+    <String, dynamic>{
+      'minimum': instance.minimum,
+    };
+
+PokemonAttack _$PokemonAttackFromJson(Map<String, dynamic> json) {
+  return PokemonAttack()
+    ..special = (json['special'] as List)
+        ?.map((e) =>
+            e == null ? null : Attack.fromJson(e as Map<String, dynamic>))
+        ?.toList();
+}
+
+Map<String, dynamic> _$PokemonAttackToJson(PokemonAttack instance) =>
+    <String, dynamic>{
+      'special': instance.special?.map((e) => e?.toJson())?.toList(),
+    };
+
+Attack _$AttackFromJson(Map<String, dynamic> json) {
+  return Attack()..name = json['name'] as String;
+}
+
+Map<String, dynamic> _$AttackToJson(Attack instance) => <String, dynamic>{
+      'name': instance.name,
+    };

--- a/example/pokemon/pubspec.lock
+++ b/example/pokemon/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.1.4"
+    version: "2.2.0"
   async:
     dependency: transitive
     description:

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -62,9 +62,17 @@ QueryDefinition generateQuery(
     List<FragmentDefinitionNode> fragmentsCommon) {
   final operation =
       document.definitions.whereType<OperationDefinitionNode>().first;
-  final fragments = fragmentsCommon.isNotEmpty
-      ? _extractFragments(operation.selectionSet, fragmentsCommon)
-      : document.definitions.whereType<FragmentDefinitionNode>().toList();
+
+  final fragments = <FragmentDefinitionNode>[];
+
+  if (fragmentsCommon.isEmpty) {
+    fragments.addAll(document.definitions.whereType<FragmentDefinitionNode>());
+  } else {
+    final fragmentsOperation =
+        _extractFragments(operation.selectionSet, fragmentsCommon);
+    document.definitions.addAll(fragmentsOperation);
+    fragments.addAll(fragmentsOperation);
+  }
 
   final basename = p.basenameWithoutExtension(path);
   final queryName = operation.name?.value ?? basename;

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -226,9 +226,9 @@ ClassProperty _selectionToClassProperty(
   );
 }
 
-List<FragmentDefinitionNode> _extractFragments(SelectionSetNode selectionSet,
+Set<FragmentDefinitionNode> _extractFragments(SelectionSetNode selectionSet,
     List<FragmentDefinitionNode> fragmentsCommon) {
-  final result = <FragmentDefinitionNode>[];
+  final result = <FragmentDefinitionNode>{};
   if (selectionSet != null) {
     selectionSet.selections.whereType<FieldNode>().forEach((selection) {
       result.addAll(_extractFragments(selection.selectionSet, fragmentsCommon));

--- a/lib/schema/options.dart
+++ b/lib/schema/options.dart
@@ -18,6 +18,9 @@ class GeneratorOptions {
   @JsonKey(defaultValue: [])
   final List<ScalarMap> scalarMapping;
 
+  /// A list of fragments apply for all query files without declare them.
+  final String fragmentsGlob;
+
   /// A list of schema mappings.
   @JsonKey(defaultValue: [])
   final List<SchemaMap> schemaMapping;
@@ -27,6 +30,7 @@ class GeneratorOptions {
     this.customParserImport,
     this.generateHelpers = true,
     this.scalarMapping = const [],
+    this.fragmentsGlob,
     this.schemaMapping = const [],
   });
 

--- a/lib/schema/options.g2.dart
+++ b/lib/schema/options.g2.dart
@@ -26,6 +26,7 @@ GeneratorOptions _$GeneratorOptionsFromJson(Map json) {
                   )))
             ?.toList() ??
         [],
+    fragmentsGlob: json['fragments_glob'] as String,
   );
 }
 
@@ -35,6 +36,7 @@ Map<String, dynamic> _$GeneratorOptionsToJson(GeneratorOptions instance) =>
       'generate_helpers': instance.generateHelpers,
       'scalar_mapping': instance.scalarMapping,
       'schema_mapping': instance.schemaMapping,
+      'fragments_glob': instance.fragmentsGlob
     };
 
 DartType _$DartTypeFromJson(Map<String, dynamic> json) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 2.1.4
+version: 2.2.0
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/test/query_generator/fragment_generator_test.dart
+++ b/test/query_generator/fragment_generator_test.dart
@@ -1,0 +1,316 @@
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:gql/ast.dart';
+import 'package:test/test.dart';
+
+import '../../lib/builder.dart';
+
+void main() {
+  group('[Fragment generation]', () {
+    test('Extracting', () async {
+      final schemeMapping = [
+        {
+          'schema': 'pokemon.schema.json',
+          'queries_glob': '**.graphql',
+          'output': 'lib/query.dart',
+        },
+        {
+          'schema': 'pokemon.schema.json',
+          'queries_glob': '**.graphql',
+          'output': 'lib/query.dart',
+        }
+      ];
+
+      final anotherBuilder = graphQLQueryBuilder(BuilderOptions(
+          {'fragments_glob': '**.frag', 'schema_mapping': schemeMapping}));
+
+      anotherBuilder.onBuild = expectAsync1((definition) {
+        expect(
+            definition.queries.first.document,
+            DocumentNode(definitions: [
+              OperationDefinitionNode(
+                  type: OperationType.query,
+                  name: null,
+                  variableDefinitions: [],
+                  directives: [],
+                  selectionSet: SelectionSetNode(selections: [
+                    FieldNode(
+                        name: NameNode(value: 'pokemon'),
+                        alias: null,
+                        arguments: [
+                          ArgumentNode(
+                              name: NameNode(value: 'name'),
+                              value: StringValueNode(
+                                  value: 'Pikachu', isBlock: false))
+                        ],
+                        directives: [],
+                        selectionSet: SelectionSetNode(selections: [
+                          FragmentSpreadNode(
+                              name: NameNode(value: 'Pokemon'), directives: []),
+                          FieldNode(
+                              name: NameNode(value: 'evolutions'),
+                              alias: null,
+                              arguments: [],
+                              directives: [],
+                              selectionSet: SelectionSetNode(selections: [
+                                FragmentSpreadNode(
+                                    name: NameNode(value: 'Pokemon'),
+                                    directives: [])
+                              ]))
+                        ]))
+                  ])),
+              FragmentDefinitionNode(
+                  name: NameNode(value: 'Pokemon'),
+                  typeCondition: TypeConditionNode(
+                      on: NamedTypeNode(
+                          name: NameNode(value: 'Pokemon'), isNonNull: false)),
+                  directives: [],
+                  selectionSet: SelectionSetNode(selections: [
+                    FieldNode(
+                        name: NameNode(value: 'id'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null),
+                    FieldNode(
+                        name: NameNode(value: 'weight'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: SelectionSetNode(selections: [
+                          FragmentSpreadNode(
+                              name: NameNode(value: 'weight'), directives: [])
+                        ])),
+                    FieldNode(
+                        name: NameNode(value: 'attacks'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: SelectionSetNode(selections: [
+                          FragmentSpreadNode(
+                              name: NameNode(value: 'pokemonAttack'),
+                              directives: [])
+                        ]))
+                  ])),
+              FragmentDefinitionNode(
+                  name: NameNode(value: 'weight'),
+                  typeCondition: TypeConditionNode(
+                      on: NamedTypeNode(
+                          name: NameNode(value: 'PokemonDimension'),
+                          isNonNull: false)),
+                  directives: [],
+                  selectionSet: SelectionSetNode(selections: [
+                    FieldNode(
+                        name: NameNode(value: 'minimum'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null)
+                  ])),
+              FragmentDefinitionNode(
+                  name: NameNode(value: 'pokemonAttack'),
+                  typeCondition: TypeConditionNode(
+                      on: NamedTypeNode(
+                          name: NameNode(value: 'PokemonAttack'),
+                          isNonNull: false)),
+                  directives: [],
+                  selectionSet: SelectionSetNode(selections: [
+                    FieldNode(
+                        name: NameNode(value: 'special'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: SelectionSetNode(selections: [
+                          FragmentSpreadNode(
+                              name: NameNode(value: 'attack'), directives: [])
+                        ]))
+                  ])),
+              FragmentDefinitionNode(
+                  name: NameNode(value: 'attack'),
+                  typeCondition: TypeConditionNode(
+                      on: NamedTypeNode(
+                          name: NameNode(value: 'Attack'), isNonNull: false)),
+                  directives: [],
+                  selectionSet: SelectionSetNode(selections: [
+                    FieldNode(
+                        name: NameNode(value: 'name'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null)
+                  ]))
+            ]));
+      }, count: schemeMapping.length);
+
+      await testBuilder(anotherBuilder, {
+        'a|fragment.frag': '''
+      fragment Pokemon on Pokemon {
+            id
+            weight {
+              ...weight
+            }
+            attacks {
+              ...pokemonAttack
+            }
+      }
+      fragment weight on PokemonDimension { minimum }
+      fragment pokemonAttack on PokemonAttack {
+        special { ...attack }
+      }
+      fragment attack on Attack { name }
+        ''',
+        'a|pokemon.schema.json': pokemonSchema,
+        'a|query.graphql': '''
+      {
+          pokemon(name: "Pikachu") {
+            ...Pokemon
+            evolutions {
+              ...Pokemon
+            }
+          }
+      }
+        ''',
+      });
+    });
+  });
+}
+
+const String pokemonSchema = '''
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "fields": [
+            {
+              "name": "query",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Query"
+              }
+            },
+            {
+              "name": "pokemon",
+              "args": [
+                {
+                  "name": "id",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String"
+                  }
+                },
+                {
+                  "name": "name",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String"
+                  }
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Pokemon"
+              }
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Pokemon",
+          "fields": [
+            {
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID"
+                }
+              }
+            },
+            {
+              "name": "weight",
+              "type": {
+                "kind": "OBJECT",
+                "name": "PokemonDimension"
+              }
+            },
+            {
+              "name": "attacks",
+              "type": {
+                "kind": "OBJECT",
+                "name": "PokemonAttack"
+              }
+            },
+            {
+              "name": "evolutions",
+              "type": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Pokemon"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID"
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PokemonDimension",
+          "fields": [
+            {
+              "name": "minimum",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              }
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PokemonAttack",
+          "fields": [
+            {
+              "name": "special",
+              "type": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Attack"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String"
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Attack",
+          "fields": [
+            {
+              "name": "name",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+''';

--- a/test/query_generator/fragment_generator_test.dart
+++ b/test/query_generator/fragment_generator_test.dart
@@ -8,21 +8,16 @@ import '../../lib/builder.dart';
 void main() {
   group('[Fragment generation]', () {
     test('Extracting', () async {
-      final schemeMapping = [
-        {
-          'schema': 'pokemon.schema.json',
-          'queries_glob': '**.graphql',
-          'output': 'lib/query.dart',
-        },
-        {
-          'schema': 'pokemon.schema.json',
-          'queries_glob': '**.graphql',
-          'output': 'lib/query.dart',
-        }
-      ];
-
-      final anotherBuilder = graphQLQueryBuilder(BuilderOptions(
-          {'fragments_glob': '**.frag', 'schema_mapping': schemeMapping}));
+      final anotherBuilder = graphQLQueryBuilder(BuilderOptions({
+        'fragments_glob': '**.frag',
+        'schema_mapping': [
+          {
+            'schema': 'pokemon.schema.json',
+            'queries_glob': '**.graphql',
+            'output': 'lib/query.dart',
+          }
+        ]
+      }));
 
       anotherBuilder.onBuild = expectAsync1((definition) {
         expect(
@@ -140,7 +135,7 @@ void main() {
                         selectionSet: null)
                   ]))
             ]));
-      }, count: schemeMapping.length);
+      }, count: 1);
 
       await testBuilder(anotherBuilder, {
         'a|fragment.frag': '''
@@ -170,6 +165,214 @@ void main() {
           }
       }
         ''',
+      }, outputs: {
+        'a|lib/query.dart': '''// GENERATED CODE - DO NOT MODIFY BY HAND
+
+import 'package:artemis/artemis.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
+import 'package:gql/ast.dart';
+part 'query.g.dart';
+
+mixin WeightMixin {
+  String minimum;
+}
+mixin AttackMixin {
+  String name;
+}
+mixin PokemonAttackMixin {
+  List<Attack> special;
+}
+mixin PokemonMixin {
+  String id;
+  PokemonDimension weight;
+  PokemonAttack attacks;
+}
+
+@JsonSerializable(explicitToJson: true)
+class Query with EquatableMixin {
+  Query();
+
+  factory Query.fromJson(Map<String, dynamic> json) => _\$QueryFromJson(json);
+
+  Pokemon pokemon;
+
+  @override
+  List<Object> get props => [pokemon];
+  Map<String, dynamic> toJson() => _\$QueryToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class Pokemon with EquatableMixin, PokemonMixin {
+  Pokemon();
+
+  factory Pokemon.fromJson(Map<String, dynamic> json) =>
+      _\$PokemonFromJson(json);
+
+  List<Pokemon> evolutions;
+
+  @override
+  List<Object> get props => [id, weight, attacks, evolutions];
+  Map<String, dynamic> toJson() => _\$PokemonToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class PokemonDimension with EquatableMixin, WeightMixin {
+  PokemonDimension();
+
+  factory PokemonDimension.fromJson(Map<String, dynamic> json) =>
+      _\$PokemonDimensionFromJson(json);
+
+  @override
+  List<Object> get props => [minimum];
+  Map<String, dynamic> toJson() => _\$PokemonDimensionToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class PokemonAttack with EquatableMixin, PokemonAttackMixin {
+  PokemonAttack();
+
+  factory PokemonAttack.fromJson(Map<String, dynamic> json) =>
+      _\$PokemonAttackFromJson(json);
+
+  @override
+  List<Object> get props => [special];
+  Map<String, dynamic> toJson() => _\$PokemonAttackToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class Attack with EquatableMixin, AttackMixin {
+  Attack();
+
+  factory Attack.fromJson(Map<String, dynamic> json) => _\$AttackFromJson(json);
+
+  @override
+  List<Object> get props => [name];
+  Map<String, dynamic> toJson() => _\$AttackToJson(this);
+}
+
+class QueryQuery extends GraphQLQuery<Query, JsonSerializable> {
+  QueryQuery();
+
+  @override
+  final DocumentNode document = DocumentNode(definitions: [
+    OperationDefinitionNode(
+        type: OperationType.query,
+        name: null,
+        variableDefinitions: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+              name: NameNode(value: 'pokemon'),
+              alias: null,
+              arguments: [
+                ArgumentNode(
+                    name: NameNode(value: 'name'),
+                    value: StringValueNode(value: 'Pikachu', isBlock: false))
+              ],
+              directives: [],
+              selectionSet: SelectionSetNode(selections: [
+                FragmentSpreadNode(
+                    name: NameNode(value: 'Pokemon'), directives: []),
+                FieldNode(
+                    name: NameNode(value: 'evolutions'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FragmentSpreadNode(
+                          name: NameNode(value: 'Pokemon'), directives: [])
+                    ]))
+              ]))
+        ])),
+    FragmentDefinitionNode(
+        name: NameNode(value: 'Pokemon'),
+        typeCondition: TypeConditionNode(
+            on: NamedTypeNode(
+                name: NameNode(value: 'Pokemon'), isNonNull: false)),
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+              name: NameNode(value: 'id'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: null),
+          FieldNode(
+              name: NameNode(value: 'weight'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: SelectionSetNode(selections: [
+                FragmentSpreadNode(
+                    name: NameNode(value: 'weight'), directives: [])
+              ])),
+          FieldNode(
+              name: NameNode(value: 'attacks'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: SelectionSetNode(selections: [
+                FragmentSpreadNode(
+                    name: NameNode(value: 'pokemonAttack'), directives: [])
+              ]))
+        ])),
+    FragmentDefinitionNode(
+        name: NameNode(value: 'weight'),
+        typeCondition: TypeConditionNode(
+            on: NamedTypeNode(
+                name: NameNode(value: 'PokemonDimension'), isNonNull: false)),
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+              name: NameNode(value: 'minimum'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: null)
+        ])),
+    FragmentDefinitionNode(
+        name: NameNode(value: 'pokemonAttack'),
+        typeCondition: TypeConditionNode(
+            on: NamedTypeNode(
+                name: NameNode(value: 'PokemonAttack'), isNonNull: false)),
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+              name: NameNode(value: 'special'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: SelectionSetNode(selections: [
+                FragmentSpreadNode(
+                    name: NameNode(value: 'attack'), directives: [])
+              ]))
+        ])),
+    FragmentDefinitionNode(
+        name: NameNode(value: 'attack'),
+        typeCondition: TypeConditionNode(
+            on: NamedTypeNode(
+                name: NameNode(value: 'Attack'), isNonNull: false)),
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+              name: NameNode(value: 'name'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: null)
+        ]))
+  ]);
+
+  @override
+  final String operationName = 'query';
+
+  @override
+  List<Object> get props => [document, operationName];
+  @override
+  Query parse(Map<String, dynamic> json) => Query.fromJson(json);
+}
+'''
       });
     });
   });


### PR DESCRIPTION
Sharing fragment between queries and schemas.

This feature only enable if developer declare input `fragments_glob` like [those](https://github.com/comigor/artemis#configuration) configuration. If it isn't declared, Artemis will turn back to original.

Will work well if it is declared within `queries_glob` defined on directly path.

Good 
```
- schema: pokemon.schema.json
  queries_glob: graphql/a.graphql
  output: lib/graphql/a.dart
- schema: pokemon.schema.json
  queries_glob: graphql/b.graphql
  output: lib/graphql/b.dart
```
Failed 
```
- schema: pokemon.schema.json
  queries_glob: graphql/*.graphql
  output: lib/graphql/common.dart
```

Because in original source, even if i have 2 fragments with same name, `add_query_prefix: true` in 2 different files, different query (operation) name and `build.yaml` config like 'Failed' above. Artemis will not generate too.

So i came up with that solution.

In a huge project my team working on it's convenient to use sharing fragments.

Already considered this issue: #52 