### PR TITLE
Dispose the underlining http client

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,6 +10,8 @@ jobs:
       uses: actions/checkout@master
     - name: Run tests
       uses: comigor/actions/dart-test@master
+      env:
+        DTA_EXCLUDE_REGEX: example
   check-version-and-changelog:
     needs: test
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 3.1.0
+- Allow to dispose `ArtemisClient` underlining http client when possible
+
 ## 3.0.0
 - BREAKING: Marks non nullable input field as `@required` [#68](https://github.com/comigor/artemis/pull/68)
 

--- a/example/graphbrainz/pubspec.lock
+++ b/example/graphbrainz/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.2.2"
+    version: "3.1.0"
   async:
     dependency: transitive
     description:
@@ -217,7 +217,7 @@ packages:
       name: gql_http_link
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.6"
   gql_link:
     dependency: transitive
     description:

--- a/example/pokemon/lib/main.dart
+++ b/example/pokemon/lib/main.dart
@@ -19,6 +19,7 @@ Future<void> main() async {
 
   final simpleQueryResponse = await client.execute(simpleQuery);
   final bigQueryResponse = await client.execute(bigQuery);
+  client.dispose();
 
   print('Simple query response: ${simpleQueryResponse.data.pokemon.number}');
 

--- a/example/pokemon/pubspec.lock
+++ b/example/pokemon/pubspec.lock
@@ -217,7 +217,7 @@ packages:
       name: gql_http_link
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.2.6"
   gql_link:
     dependency: transitive
     description:

--- a/example/pokemon/pubspec.lock
+++ b/example/pokemon/pubspec.lock
@@ -217,7 +217,7 @@ packages:
       name: gql_http_link
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.3.0"
   gql_link:
     dependency: transitive
     description:

--- a/example/pokemon/pubspec.lock
+++ b/example/pokemon/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.2.2"
+    version: "3.1.0"
   async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 3.0.0
+version: 3.1.0
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   gql_code_gen: ^0.1.5
   gql_dedupe_link: ^1.0.8
   gql_exec: ^0.2.0
-  gql_http_link: ^0.3.0
+  gql_http_link: ^0.2.6
   gql_link: ^0.2.2
   gql: ^0.12.0
   http: ^0.12.0+2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,11 +18,7 @@ dependencies:
   gql_code_gen: ^0.1.5
   gql_dedupe_link: ^1.0.8
   gql_exec: ^0.2.0
-  gql_http_link:
-    git:
-      url: git@github.com:comigor/gql.git
-      ref: 570482ebbc025d70e1e977aae68b50c721e8c8e9
-      path: gql_http_link
+  gql_http_link: ^0.3.0
   gql_link: ^0.2.2
   gql: ^0.12.0
   http: ^0.12.0+2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,11 @@ dependencies:
   gql_code_gen: ^0.1.5
   gql_dedupe_link: ^1.0.8
   gql_exec: ^0.2.0
-  gql_http_link: ^0.2.5
+  gql_http_link:
+    git:
+      url: git@github.com:comigor/gql.git
+      ref: 570482ebbc025d70e1e977aae68b50c721e8c8e9
+      path: gql_http_link
   gql_link: ^0.2.2
   gql: ^0.12.0
   http: ^0.12.0+2


### PR DESCRIPTION
Create a dispose method on ArtemisClient to close the underlining http client when possible.

Depends on https://github.com/gql-dart/gql/pull/39