### PR TITLE
Add .graphql extension to generated output files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 5.1.0
+- Add `.graphql.` to outputted files path, in a non-breaking change way: a
+"forwarder" file will be generated to make it retro-compatible when a
+configurated output doesn't end with `.graphql.dart`.
+
 ## 5.0.4
 - Update CI to include beta branch.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Check the [**beta**](https://github.com/comigor/artemis/tree/beta) branch for the bleeding edge (and breaking) stuff.
 
-Artemis is a code generator that looks for `schema.graphql` (GraphQL SDL - Schema Definition Language) and `*.graphql` files and builds `.dart` files typing that query, based on the schema. That's similar to what [Apollo](https://github.com/apollographql/apollo-client) does (Artemis is his sister anyway).
+Artemis is a code generator that looks for `schema.graphql` (GraphQL SDL - Schema Definition Language) and `*.graphql` files and builds `.graphql.dart` files typing that query, based on the schema. That's similar to what [Apollo](https://github.com/apollographql/apollo-client) does (Artemis is his sister anyway).
 
 ---
 
@@ -99,7 +99,7 @@ Each `SchemaMap` is configured this way:
 
 | Option | Default value | Description |
 | - | - | - |
-| `output` |  | Relative path to output the generated code. |
+| `output` |  | Relative path to output the generated code. It should end with `.graphql.dart` or else the  generator will need to generate one more file. |
 | `schema` |  | Relative path to the GraphQL schema. |
 | `queries_glob` |  | Glob that selects all query files to be used with this schema. |
 | `type_name_field` | `__typename` | The name of the field used to differentiatiate interfaces and union types (commonly `__typename` or `__resolveType`). Note that `__typename` field are not added automatically to the query. If you want interface/union type resolution, you need to manually add it there. |

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Each `SchemaMap` is configured this way:
 
 | Option | Default value | Description |
 | - | - | - |
-| `output` |  | Relative path to output the generated code. It should end with `.graphql.dart` or else the  generator will need to generate one more file. |
+| `output` |  | Relative path to output the generated code. It should end with `.graphql.dart` or else the generator will need to generate one more file. |
 | `schema` |  | Relative path to the GraphQL schema. |
 | `queries_glob` |  | Glob that selects all query files to be used with this schema. |
 | `type_name_field` | `__typename` | The name of the field used to differentiatiate interfaces and union types (commonly `__typename` or `__resolveType`). Note that `__typename` field are not added automatically to the query. If you want interface/union type resolution, you need to manually add it there. |

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -108,7 +108,7 @@ QueryDefinition generateQuery(
     fragments.addAll(fragmentsOperation);
   }
 
-  final basename = p.basenameWithoutExtension(path);
+  final basename = p.basenameWithoutExtension(path).split('.').first;
   final queryName = operation.name?.value ?? basename;
   final className = ReCase(queryName).pascalCase;
 

--- a/lib/generator/print_helpers.dart
+++ b/lib/generator/print_helpers.dart
@@ -371,3 +371,9 @@ void writeLibraryDefinitionToBuffer(
   buffer.writeln('// GENERATED CODE - DO NOT MODIFY BY HAND\n');
   buffer.write(specToString(generateLibrarySpec(definition)));
 }
+
+/// Generate an empty file just exporting the library. This is used to avoid
+/// a breaking change on file generation.
+String writeLibraryForwarder(LibraryDefinition definition) =>
+    '''// GENERATED CODE - DO NOT MODIFY BY HAND
+export '${definition.basename}.dart';''';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 5.0.4
+version: 5.1.0
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/test/generator/print_helpers_test.dart
+++ b/test/generator/print_helpers_test.dart
@@ -367,7 +367,7 @@ class AClass with EquatableMixin {
 
     test('It should generated an empty file by default.', () {
       final buffer = StringBuffer();
-      final definition = LibraryDefinition(basename: 'test_query');
+      final definition = LibraryDefinition(basename: r'test_query.graphql');
 
       writeLibraryDefinitionToBuffer(buffer, definition);
 
@@ -376,14 +376,14 @@ class AClass with EquatableMixin {
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'test_query.g.dart';
+part 'test_query.graphql.g.dart';
 ''');
     });
 
     test('When there are custom imports, they are included.', () {
       final buffer = StringBuffer();
       final definition = LibraryDefinition(
-          basename: 'test_query', customImports: ['some_file.dart']);
+          basename: r'test_query.graphql', customImports: ['some_file.dart']);
 
       writeLibraryDefinitionToBuffer(buffer, definition);
 
@@ -393,14 +393,14 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
 import 'some_file.dart';
-part 'test_query.g.dart';
+part 'test_query.graphql.g.dart';
 ''');
     });
 
     test('When generateHelpers is true, an execute fn is generated.', () {
       final buffer = StringBuffer();
       final definition = LibraryDefinition(
-        basename: 'test_query',
+        basename: r'test_query.graphql',
         queries: [
           QueryDefinition(
             queryName: 'test_query',
@@ -419,7 +419,7 @@ import 'package:artemis/artemis.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'test_query.g.dart';
+part 'test_query.graphql.g.dart';
 
 class TestQueryQuery extends GraphQLQuery<TestQuery, JsonSerializable> {
   TestQueryQuery();
@@ -447,7 +447,8 @@ class TestQueryQuery extends GraphQLQuery<TestQuery, JsonSerializable> {
 
     test('The generated execute fn could have input.', () {
       final buffer = StringBuffer();
-      final definition = LibraryDefinition(basename: 'test_query', queries: [
+      final definition =
+          LibraryDefinition(basename: r'test_query.graphql', queries: [
         QueryDefinition(
           queryName: 'test_query',
           queryType: 'TestQuery',
@@ -465,7 +466,7 @@ import 'package:artemis/artemis.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'test_query.g.dart';
+part 'test_query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class TestQueryArguments extends JsonSerializable with EquatableMixin {
@@ -577,7 +578,8 @@ class TestQueryArguments extends JsonSerializable with EquatableMixin {
 
     test('It will accept and write class/enum definitions.', () {
       final buffer = StringBuffer();
-      final definition = LibraryDefinition(basename: 'test_query', queries: [
+      final definition =
+          LibraryDefinition(basename: r'test_query.graphql', queries: [
         QueryDefinition(
           queryName: 'test_query',
           queryType: 'TestQuery',
@@ -596,7 +598,7 @@ class TestQueryArguments extends JsonSerializable with EquatableMixin {
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'test_query.g.dart';
+part 'test_query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class AClass with EquatableMixin {

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -20,6 +20,7 @@ Future testGenerator({
   bool generateHelpers = false,
   Map<String, dynamic> builderOptionsMap = const {},
   Map<String, dynamic> sourceAssetsMap = const {},
+  Map<String, dynamic> outputsMap = const {},
 }) async {
   assert((schema) != null);
 
@@ -29,7 +30,7 @@ Future testGenerator({
       {
         'schema': 'api.schema.graphql',
         'queries_glob': 'queries/**.graphql',
-        'output': 'lib/query.dart',
+        'output': 'lib/query.graphql.dart',
       }
     ],
     ...builderOptionsMap,
@@ -48,7 +49,8 @@ Future testGenerator({
       ...sourceAssetsMap,
     },
     outputs: {
-      'a|lib/query.dart': generatedFile,
+      'a|lib/query.graphql.dart': generatedFile,
+      ...outputsMap,
     },
     onLog: debug,
   );

--- a/test/query_generator/aliases/alias_on_leaves_test.dart
+++ b/test/query_generator/aliases/alias_on_leaves_test.dart
@@ -47,7 +47,7 @@ const query = r'''
         ''';
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       document: parseString(query),
       queryName: r'some_query',
@@ -100,7 +100,7 @@ const generatedFile = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class SomeQuery$Response$SomeObject with EquatableMixin {

--- a/test/query_generator/aliases/alias_on_object_test.dart
+++ b/test/query_generator/aliases/alias_on_object_test.dart
@@ -46,7 +46,7 @@ const query = r'''
 ''';
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       document: parseString(query),
       queryName: r'some_query',
@@ -108,7 +108,7 @@ const generatedFile = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class SomeQuery$QueryResponse$SomeObject with EquatableMixin {

--- a/test/query_generator/ast_schema/field_not_found_mutation_test.dart
+++ b/test/query_generator/ast_schema/field_not_found_mutation_test.dart
@@ -51,7 +51,7 @@ mutation createThing($createThingInput: CreateThingInput) {
 ''';
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'createThing',
       queryType: r'CreateThing$MutationRoot',
@@ -137,7 +137,7 @@ import 'package:meta/meta.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class CreateThing$MutationRoot$CreateThingResponse$Thing with EquatableMixin {

--- a/test/query_generator/ast_schema/input_types_test.dart
+++ b/test/query_generator/ast_schema/input_types_test.dart
@@ -56,7 +56,7 @@ mutation createThing($createThingInput: CreateThingInput) {
 ''';
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'createThing',
       queryType: r'CreateThing$MutationRoot',
@@ -161,7 +161,7 @@ import 'package:meta/meta.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class CreateThing$MutationRoot$CreateThingResponse$Thing with EquatableMixin {

--- a/test/query_generator/ast_schema/missing_schema_test.dart
+++ b/test/query_generator/ast_schema/missing_schema_test.dart
@@ -28,7 +28,7 @@ query {
 ''';
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'query',
       queryType: r'Query$Query',
@@ -56,7 +56,7 @@ const generatedFile = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class Query$Query with EquatableMixin {

--- a/test/query_generator/complex_input_objects_test.dart
+++ b/test/query_generator/complex_input_objects_test.dart
@@ -47,7 +47,7 @@ void main() {
 }
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'some_query',
       queryType: r'SomeQuery$QueryRoot',
@@ -124,7 +124,7 @@ import 'package:artemis/artemis.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class SomeQuery$QueryRoot$SomeObject with EquatableMixin {

--- a/test/query_generator/enums/enum_list_test.dart
+++ b/test/query_generator/enums/enum_list_test.dart
@@ -42,7 +42,7 @@ query custom {
 ''';
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'custom',
       queryType: r'Custom$QueryRoot',
@@ -86,7 +86,7 @@ const generatedFile = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class Custom$QueryRoot$QueryResponse with EquatableMixin {

--- a/test/query_generator/enums/input_enum_test.dart
+++ b/test/query_generator/enums/input_enum_test.dart
@@ -53,7 +53,7 @@ const query = r'''
 ''';
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'custom',
       queryType: r'Custom$QueryRoot',
@@ -121,7 +121,7 @@ import 'package:artemis/artemis.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class Custom$QueryRoot$QueryResponse with EquatableMixin {

--- a/test/query_generator/enums/query_enum_test.dart
+++ b/test/query_generator/enums/query_enum_test.dart
@@ -43,7 +43,7 @@ const query = r'''
 ''';
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'custom',
       queryType: r'Custom$QueryRoot',
@@ -89,7 +89,7 @@ const generatedFile = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class Custom$QueryRoot$QueryResponse with EquatableMixin {

--- a/test/query_generator/forwarder_test.dart
+++ b/test/query_generator/forwarder_test.dart
@@ -1,0 +1,91 @@
+import 'package:artemis/generator/data.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+
+void main() {
+  group('On forwarder', () {
+    test(
+      'Forwarder are created if output file does not end with .graphql.dart',
+      () async => testGenerator(
+        query: query,
+        libraryDefinition: libraryDefinition,
+        generatedFile: generatedFile,
+        schema: r'''
+          schema {
+            query: QueryRoot
+          }
+
+          type QueryRoot {
+            a: String
+          }''',
+        builderOptionsMap: {
+          'schema_mapping': [
+            {
+              'schema': 'api.schema.graphql',
+              'queries_glob': 'queries/**.graphql',
+              'output': 'lib/query.dart',
+            }
+          ],
+        },
+        outputsMap: {
+          'a|lib/query.graphql.dart': generatedFile,
+          'a|lib/query.dart': r'''// GENERATED CODE - DO NOT MODIFY BY HAND
+export 'query.graphql.dart';''',
+        },
+      ),
+    );
+  });
+}
+
+const query = r'''
+query custom {
+  a
+}
+''';
+
+final LibraryDefinition libraryDefinition =
+    LibraryDefinition(basename: r'query.graphql', queries: [
+  QueryDefinition(
+      queryName: r'custom',
+      queryType: r'Custom$QueryRoot',
+      classes: [
+        ClassDefinition(
+            name: r'Custom$QueryRoot',
+            properties: [
+              ClassProperty(
+                  type: r'String',
+                  name: r'a',
+                  isOverride: false,
+                  isNonNull: false,
+                  isResolveType: false)
+            ],
+            factoryPossibilities: {},
+            typeNameField: r'__typename',
+            isInput: false)
+      ],
+      generateHelpers: false,
+      suffix: r'Query')
+]);
+
+const generatedFile = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
+
+import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
+import 'package:gql/ast.dart';
+part 'query.graphql.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class Custom$QueryRoot with EquatableMixin {
+  Custom$QueryRoot();
+
+  factory Custom$QueryRoot.fromJson(Map<String, dynamic> json) =>
+      _$Custom$QueryRootFromJson(json);
+
+  String a;
+
+  @override
+  List<Object> get props => [a];
+  Map<String, dynamic> toJson() => _$Custom$QueryRootToJson(this);
+}
+''';

--- a/test/query_generator/fragments/fragment_glob_test.dart
+++ b/test/query_generator/fragments/fragment_glob_test.dart
@@ -85,7 +85,7 @@ const queryString = '''
 ''';
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'query',
       queryType: r'Query$Query',
@@ -185,7 +185,7 @@ import 'package:artemis/artemis.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 mixin Query$PokemonMixin {
   String id;

--- a/test/query_generator/fragments/fragment_on_fragments_test.dart
+++ b/test/query_generator/fragments/fragment_on_fragments_test.dart
@@ -54,7 +54,7 @@ const queryString = '''
 ''';
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'query',
       queryType: r'Query$Query',
@@ -110,7 +110,7 @@ const generatedFile = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 mixin Query$PokemonMixin {
   String id;

--- a/test/query_generator/fragments/fragments_multiple_test.dart
+++ b/test/query_generator/fragments/fragments_multiple_test.dart
@@ -78,7 +78,7 @@ void main() {
 }
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'VoyagesData',
       queryType: r'VoyagesData$Query',
@@ -220,7 +220,7 @@ import 'package:artemis/artemis.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 mixin VoyagesData$DstMixin {
   String id;

--- a/test/query_generator/fragments/fragments_test.dart
+++ b/test/query_generator/fragments/fragments_test.dart
@@ -35,7 +35,7 @@ void main() {
 }
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'some_query',
       queryType: r'SomeQuery$SomeObject',
@@ -67,7 +67,7 @@ const generatedFile = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 mixin SomeQuery$MyFragmentMixin {
   String s;

--- a/test/query_generator/interfaces/interface_possible_types_test.dart
+++ b/test/query_generator/interfaces/interface_possible_types_test.dart
@@ -66,7 +66,7 @@ const graphQLSchema = '''
 ''';
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'custom',
       queryType: r'Custom$Query',
@@ -147,7 +147,7 @@ import 'package:meta/meta.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class Custom$Query$Node$User extends Custom$Query$Node with EquatableMixin {

--- a/test/query_generator/interfaces/interface_test.dart
+++ b/test/query_generator/interfaces/interface_test.dart
@@ -69,7 +69,7 @@ final String graphQLSchema = r'''
 ''';
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'custom',
       queryType: r'Custom$Query',
@@ -170,7 +170,7 @@ import 'package:meta/meta.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 mixin Custom$UserFragMixin {
   String id;

--- a/test/query_generator/multiple_queries_test.dart
+++ b/test/query_generator/multiple_queries_test.dart
@@ -30,7 +30,7 @@ void main() {
 }
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'some_query',
       queryType: r'SomeQuery$SomeObject',
@@ -63,7 +63,7 @@ const generatedFile = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class SomeQuery$SomeObject with EquatableMixin {

--- a/test/query_generator/mutations_test.dart
+++ b/test/query_generator/mutations_test.dart
@@ -43,7 +43,7 @@ mutation custom($input: Input!) {
 ''';
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'custom',
       queryType: r'Custom$MutationRoot',
@@ -99,7 +99,7 @@ import 'package:artemis/artemis.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class Custom$MutationRoot$MutationResponse with EquatableMixin {

--- a/test/query_generator/query_generator_test.dart
+++ b/test/query_generator/query_generator_test.dart
@@ -2,7 +2,6 @@ import 'package:artemis/builder.dart';
 import 'package:artemis/generator/data.dart';
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
-import 'package:gql/language.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
@@ -29,14 +28,14 @@ void main() {
           {
             'schema': 'api.schema.graphql',
             'queries_glob': 'queries/**.graphql',
-            'output': 'lib/some_query.dart',
+            'output': 'lib/some_query.graphql.dart',
           }
         ]
       }));
 
       anotherBuilder.onBuild = expectAsync1((definition) {
         final libraryDefinition =
-            LibraryDefinition(basename: r'some_query', queries: [
+            LibraryDefinition(basename: r'some_query.graphql', queries: [
           QueryDefinition(
               queryName: r'some_query',
               queryType: r'SomeQuery$SomeObject',
@@ -71,12 +70,13 @@ void main() {
           'a|queries/some_query.graphql': 'query some_query { s, i }',
         },
         outputs: {
-          'a|lib/some_query.dart': r'''// GENERATED CODE - DO NOT MODIFY BY HAND
+          'a|lib/some_query.graphql.dart':
+              r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'some_query.g.dart';
+part 'some_query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class SomeQuery$SomeObject with EquatableMixin {
@@ -105,7 +105,7 @@ class SomeQuery$SomeObject with EquatableMixin {
           {
             'schema': 'api.schema.grqphql',
             'queries_glob': 'queries/**.graphql',
-            'output': 'lib/some_query.dart',
+            'output': 'lib/some_query.graphql.dart',
           }
         ]
       }));
@@ -122,7 +122,7 @@ class SomeQuery$SomeObject with EquatableMixin {
 
       anotherBuilder.onBuild = expectAsync1((definition) {
         final libraryDefinition =
-            LibraryDefinition(basename: r'some_query', queries: [
+            LibraryDefinition(basename: r'some_query.graphql', queries: [
           QueryDefinition(
               queryName: r'some_query',
               queryType: r'SomeQuery$Query',
@@ -201,14 +201,15 @@ class SomeQuery$SomeObject with EquatableMixin {
           'a|queries/some_query.graphql': query
         },
         outputs: {
-          'a|lib/some_query.dart': r'''// GENERATED CODE - DO NOT MODIFY BY HAND
+          'a|lib/some_query.graphql.dart':
+              r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 
 import 'package:meta/meta.dart';
 import 'package:artemis/artemis.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'some_query.g.dart';
+part 'some_query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class SomeQuery$Query$SomeObject with EquatableMixin {
@@ -351,14 +352,14 @@ class SomeQueryQuery extends GraphQLQuery<SomeQuery$Query, SomeQueryArguments> {
           {
             'schema': 'api.schema.grqphql',
             'queries_glob': 'queries/**.graphql',
-            'output': 'lib/some_query.dart',
+            'output': 'lib/some_query.graphql.dart',
           }
         ]
       }));
 
       anotherBuilder.onBuild = expectAsync1((definition) {
         final libraryDefinition =
-            LibraryDefinition(basename: r'some_query', queries: [
+            LibraryDefinition(basename: r'some_query.graphql', queries: [
           QueryDefinition(
               queryName: r'some_query',
               queryType: r'SomeQuery$Result',
@@ -436,12 +437,13 @@ class SomeQueryQuery extends GraphQLQuery<SomeQuery$Query, SomeQueryArguments> {
           'a|queries/some_query.graphql': document,
         },
         outputs: {
-          'a|lib/some_query.dart': r'''// GENERATED CODE - DO NOT MODIFY BY HAND
+          'a|lib/some_query.graphql.dart':
+              r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'some_query.g.dart';
+part 'some_query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class SomeQuery$Result$SomeObject$AnotherObject with EquatableMixin {
@@ -503,14 +505,14 @@ class SomeQuery$Result with EquatableMixin {
           {
             'schema': 'api.schema.graphql',
             'queries_glob': 'queries/**.graphql',
-            'output': 'lib/some_query.dart',
+            'output': 'lib/some_query.graphql.dart',
           }
         ]
       }));
 
       anotherBuilder.onBuild = expectAsync1((definition) {
         final libraryDefinition =
-            LibraryDefinition(basename: r'some_query', queries: [
+            LibraryDefinition(basename: r'some_query.graphql', queries: [
           QueryDefinition(
               queryName: r'some_query',
               queryType: r'SomeQuery$Result',
@@ -555,12 +557,13 @@ class SomeQuery$Result with EquatableMixin {
               'query some_query { firstName: s, lastName: st }',
         },
         outputs: {
-          'a|lib/some_query.dart': r'''// GENERATED CODE - DO NOT MODIFY BY HAND
+          'a|lib/some_query.graphql.dart':
+              r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'some_query.g.dart';
+part 'some_query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class SomeQuery$Result with EquatableMixin {
@@ -590,7 +593,7 @@ class SomeQuery$Result with EquatableMixin {
           {
             'schema': 'api.schema.graphql',
             'queries_glob': 'queries/**.graphql',
-            'output': 'lib/some_query.dart',
+            'output': 'lib/some_query.graphql.dart',
           },
         ],
         'scalar_mapping': [
@@ -612,7 +615,7 @@ class SomeQuery$Result with EquatableMixin {
 
       anotherBuilder.onBuild = expectAsync1((definition) {
         final libraryDefinition =
-            LibraryDefinition(basename: r'some_query', queries: [
+            LibraryDefinition(basename: r'some_query.graphql', queries: [
           QueryDefinition(
               queryName: r'some_query',
               queryType: r'SomeQuery$SomeObject',
@@ -657,13 +660,14 @@ class SomeQuery$Result with EquatableMixin {
               'query some_query { bigDecimal, dateTime }',
         },
         outputs: {
-          'a|lib/some_query.dart': r'''// GENERATED CODE - DO NOT MODIFY BY HAND
+          'a|lib/some_query.graphql.dart':
+              r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
 import 'package:decimal/decimal.dart';
-part 'some_query.g.dart';
+part 'some_query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class SomeQuery$SomeObject with EquatableMixin {
@@ -693,28 +697,29 @@ class SomeQuery$SomeObject with EquatableMixin {
           {
             'schema': 'api.schema.graphql',
             'queries_glob': 'queries/**.graphql',
-            'output': 'lib/pascal_casing_query.dart',
+            'output': 'lib/pascal_casing_query.graphql.dart',
           }
-        ]
+        ],
       }));
 
       anotherBuilder.onBuild = expectAsync1((definition) {
-        final libraryDefinition =
-            LibraryDefinition(basename: r'pascal_casing_query', queries: [
-          QueryDefinition(
-              queryName: r'PascalCasingQuery',
-              queryType: r'PascalCasingQuery$PascalCasingQuery',
-              classes: [
-                ClassDefinition(
-                    name: r'PascalCasingQuery$PascalCasingQuery',
-                    properties: [
-                      ClassProperty(
-                          type: r'String', name: r's', isOverride: false)
-                    ],
-                    typeNameField: r'__typename')
-              ],
-              generateHelpers: false)
-        ]);
+        final libraryDefinition = LibraryDefinition(
+            basename: r'pascal_casing_query.graphql',
+            queries: [
+              QueryDefinition(
+                  queryName: r'PascalCasingQuery',
+                  queryType: r'PascalCasingQuery$PascalCasingQuery',
+                  classes: [
+                    ClassDefinition(
+                        name: r'PascalCasingQuery$PascalCasingQuery',
+                        properties: [
+                          ClassProperty(
+                              type: r'String', name: r's', isOverride: false)
+                        ],
+                        typeNameField: r'__typename')
+                  ],
+                  generateHelpers: false)
+            ]);
         expect(definition, libraryDefinition);
       }, count: 1);
 
@@ -734,13 +739,13 @@ class SomeQuery$SomeObject with EquatableMixin {
               'query PascalCasingQuery { s }',
         },
         outputs: {
-          'a|lib/pascal_casing_query.dart':
+          'a|lib/pascal_casing_query.graphql.dart':
               r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'pascal_casing_query.g.dart';
+part 'pascal_casing_query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class PascalCasingQuery$PascalCasingQuery with EquatableMixin {

--- a/test/query_generator/scalars/custom_scalars_test.dart
+++ b/test/query_generator/scalars/custom_scalars_test.dart
@@ -99,7 +99,7 @@ void main() {
 }
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'query',
       queryType: r'Query$SomeObject',
@@ -121,7 +121,7 @@ final LibraryDefinition libraryDefinition =
 ]);
 
 final LibraryDefinition libraryDefinitionWithCustomParserFns =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'query',
       queryType: r'Query$SomeObject',
@@ -147,7 +147,7 @@ final LibraryDefinition libraryDefinitionWithCustomParserFns =
 ]);
 
 final LibraryDefinition libraryDefinitionWithCustomImports =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       queryName: r'query',
       queryType: r'Query$SomeObject',
@@ -178,7 +178,7 @@ const generatedFile = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class Query$SomeObject with EquatableMixin {
@@ -202,7 +202,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
 import 'package:example/src/custom_parser.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class Query$SomeObject with EquatableMixin {
@@ -230,7 +230,7 @@ import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
 import 'package:uuid/uuid.dart';
 import 'package:example/src/custom_parser.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class Query$SomeObject with EquatableMixin {

--- a/test/query_generator/scalars/scalars_test.dart
+++ b/test/query_generator/scalars/scalars_test.dart
@@ -63,7 +63,7 @@ void main() {
 final String query = 'query some_query { i, f, s, b, id }';
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
     document: parseString(query),
     queryName: r'some_query',
@@ -85,7 +85,7 @@ const generatedFile = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class SomeQuery$SomeObject with EquatableMixin {

--- a/test/query_generator/union_types_test.dart
+++ b/test/query_generator/union_types_test.dart
@@ -53,7 +53,7 @@ final String graphQLSchema = '''
 ''';
 
 final LibraryDefinition libraryDefinition =
-    LibraryDefinition(basename: r'query', queries: [
+    LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
       document: parseString(query),
       queryName: r'some_query',
@@ -127,7 +127,7 @@ const generatedFile = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
-part 'query.g.dart';
+part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class SomeQuery$SomeObject$SomeUnion$TypeA


### PR DESCRIPTION
So, for some time I've been having an issue with artemis when used in conjunction with other generators that depends of json_serializable (or actually combining_builder, I'm not sure). Basically, the file dependency tree on `build_runner` package was not being updated with the new files artemis was generating.

Then I realized artemis output files weren't being considered because it wouldn't match  `build_extensions`. Sadly, I can't use a build extension used by  another generator (like `.g.dart`) neither, of course, only `.dart` files. A custom unique extension must be used (and that's why it was configured as `.graphql.dart`).

So this PR adds `.graphql.` to generated files, in a non-breaking change way: a "forwarder" file will be generated to make it retro-compatible when a configuration output doesn't include `.graphql.dart` on  the path.