### PR TITLE
Use default names for query/mutation root when SDL does not declare schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 5.0.2
+- Use default names for query/mutation root when SDL does not declare `schema`.
+
 ## 5.0.1
 - Fix generation of recursive input objects introduced by 5.0.0.
 

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -118,11 +118,14 @@ QueryDefinition generateQuery(
   schema.accept(schemaVisitor);
   schema.accept(objectVisitor);
 
-  final rootTypeName = schemaVisitor.schemaDefinitionNode.operationTypes
-      .firstWhere((e) => e.operation == operation.type, orElse: () => null)
-      ?.type
-      ?.name
-      ?.value;
+  final suffix = operation.type == OperationType.query ? 'Query' : 'Mutation';
+  final rootTypeName = (schemaVisitor.schemaDefinitionNode?.operationTypes ??
+              [])
+          .firstWhere((e) => e.operation == operation.type, orElse: () => null)
+          ?.type
+          ?.name
+          ?.value ??
+      suffix;
 
   if (rootTypeName == null) {
     throw Exception(
@@ -130,8 +133,6 @@ QueryDefinition generateQuery(
   }
 
   final TypeDefinitionNode parentType = objectVisitor.getByName(rootTypeName);
-
-  final suffix = operation.type == OperationType.query ? 'Query' : 'Mutation';
 
   final visitor = _GeneratorVisitor(
     context: Context(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 5.0.1
+version: 5.0.2
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/test/query_generator/ast_schema/missing_schema_test.dart
+++ b/test/query_generator/ast_schema/missing_schema_test.dart
@@ -1,0 +1,74 @@
+import 'package:artemis/generator/data.dart';
+import 'package:test/test.dart';
+
+import '../../helpers.dart';
+
+void main() {
+  group('On AST schema', () {
+    test(
+      'When schema declaration is missing',
+      () async => testGenerator(
+        query: query,
+        schema: r'''
+          type Query {
+            a: String
+          }
+        ''',
+        libraryDefinition: libraryDefinition,
+        generatedFile: generatedFile,
+      ),
+    );
+  });
+}
+
+const query = r'''
+query {
+  a
+}
+''';
+
+final LibraryDefinition libraryDefinition =
+    LibraryDefinition(basename: r'query', queries: [
+  QueryDefinition(
+      queryName: r'query',
+      queryType: r'Query$Query',
+      classes: [
+        ClassDefinition(
+            name: r'Query$Query',
+            properties: [
+              ClassProperty(
+                  type: r'String',
+                  name: r'a',
+                  isOverride: false,
+                  isNonNull: false,
+                  isResolveType: false)
+            ],
+            factoryPossibilities: {},
+            typeNameField: r'__typename',
+            isInput: false)
+      ],
+      generateHelpers: false,
+      suffix: r'Query')
+]);
+
+const generatedFile = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
+
+import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
+import 'package:gql/ast.dart';
+part 'query.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class Query$Query with EquatableMixin {
+  Query$Query();
+
+  factory Query$Query.fromJson(Map<String, dynamic> json) =>
+      _$Query$QueryFromJson(json);
+
+  String a;
+
+  @override
+  List<Object> get props => [a];
+  Map<String, dynamic> toJson() => _$Query$QueryToJson(this);
+}
+''';


### PR DESCRIPTION
From [spec](http://spec.graphql.org/June2018/#sec-Root-Operation-Types):

>While any type can be the root operation type for a GraphQL operation, the type system definition language can omit the schema definition when the query, mutation, and subscription root types are named Query, Mutation, and Subscription respectively.

>Likewise, when representing a GraphQL schema using the type system definition language, a schema definition should be omitted if it only uses the default root operation type names.

Closes https://github.com/comigor/artemis/issues/50