### PR TITLE
Separate actions for push/pull_request and include beta branch checks

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,0 +1,56 @@
+on: pull_request
+
+name: CI
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@master
+    - name: Run tests
+      uses: comigor/actions/dart-test@master
+      env:
+        DTA_EXCLUDE_REGEX: example
+  check-version-and-changelog:
+    needs: test
+    runs-on: ubuntu-latest
+    container: golang
+    steps:
+    - uses: actions/checkout@master
+    - run: |
+        GO111MODULE=on go get -u github.com/itchyny/gojq/cmd/gojq@d24ecb5d89a9eee8b4cd2071bdff7585a8b44f0e
+        cd "$GITHUB_WORKSPACE"
+    - name: Check if version on pubspec.yaml was changed and if there's an entry for this new version on CHANGELOG
+      run: |
+        echo "GITHUB EVENT NAME: ${{ github.event_name }}"
+        echo "GITHUB REF: $GITHUB_REF"
+        echo "GITHUB REF: ${{ github.ref }}"
+        echo "GITHUB HEAD REF: ${{ github.head_ref }}"
+        echo "GITHUB BASE REF: ${{ github.base_ref }}"
+
+        git fetch --prune --unshallow
+        where="origin/${{ github.base_ref }}"
+
+        diff=$(git diff $where pubspec.yaml)
+        echo "$diff" | grep -E '\+.*version' || {
+          echo "Version not bumped on pubspec"
+          exit 1
+        }
+
+        package_version=$(cat pubspec.yaml | gojq --yaml-input -r '.version')
+
+        # If are on master or beta
+        if [ "${{ github.base_ref }}" = "master" ]; then
+          echo "$package_version" | grep beta && {
+            echo "Version cant contain beta"
+            exit 1
+          }
+        elif [ "${{ github.base_ref }}" = "beta" ]; then
+          echo "$package_version" | grep beta || {
+            echo "Missing beta on version"
+            exit 1
+          }
+        fi
+
+        cat CHANGELOG.md | grep "$package_version"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,10 +1,15 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:    
+      - master
+      - beta
 
 name: CI
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta'
     steps:
     - name: Clone repository
       uses: actions/checkout@master
@@ -15,6 +20,7 @@ jobs:
   check-version-and-changelog:
     needs: test
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta'
     container: golang
     steps:
     - uses: actions/checkout@master
@@ -23,18 +29,38 @@ jobs:
         cd "$GITHUB_WORKSPACE"
     - name: Check if version on pubspec.yaml was changed and if there's an entry for this new version on CHANGELOG
       run: |
+        echo "GITHUB EVENT NAME: ${{ github.event_name }}"
+        echo "GITHUB REF: $GITHUB_REF"
+        echo "GITHUB REF: ${{ github.ref }}"
+        echo "GITHUB HEAD REF: ${{ github.head_ref }}"
+        echo "GITHUB BASE REF: ${{ github.base_ref }}"
+
         git fetch --prune --unshallow
-        if test "${{ github.ref }}" = "refs/heads/master"; then
-          where=HEAD~$(gojq '.commits | length' "${GITHUB_EVENT_PATH}")
-        else
-          where=origin/master
-        fi
+        where=HEAD~$(gojq '.commits | length' "${GITHUB_EVENT_PATH}")
+        
         diff=$(git diff $where pubspec.yaml)
-        echo "$diff" | grep -E '\+.*version'
-        mkdir -p artifacts
-        git diff -U0 $where CHANGELOG.md | grep '^\+' | grep -Ev '^(--- a/|\+\+\+ b/)' | sed -E 's/^\+(.*)/\1/g' > artifacts/changelog
+        echo "$diff" | grep -E '\+.*version' || {
+          echo "Version not bumped on pubspec"
+          exit 1
+        }
+
         package_version=$(cat pubspec.yaml | gojq --yaml-input -r '.version')
+
+        # If are on master or beta
+        if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+          echo "$package_version" | grep beta && {
+            echo "Version cant contain beta"
+            exit 1
+          }
+        elif [ "${{ github.ref }}" = "refs/heads/beta" ]; then
+          echo "$package_version" | grep beta || {
+            echo "Missing beta on version"
+            exit 1
+          }
+        fi
+
         cat CHANGELOG.md | grep "$package_version"
+        mkdir -p artifacts
         echo "$package_version" > artifacts/version
     - uses: actions/upload-artifact@v1
       with:
@@ -43,7 +69,7 @@ jobs:
   create-tag-and-release:
     needs: check-version-and-changelog
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'master')
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta'
     steps:
     - uses: actions/checkout@master
     - uses: actions/download-artifact@v1
@@ -52,7 +78,6 @@ jobs:
     - id: vars
       run: |
         echo "::set-output name=package_version::v$(cat package_data/version)"
-        echo "::set-output name=changelog::$(cat package_data/changelog)"
     - name: Push tag
       uses: anothrNick/github-tag-action@master
       env:
@@ -65,11 +90,10 @@ jobs:
       with:
         tag_name: ${{ steps.vars.outputs.package_version }}
         release_name: Release ${{ steps.vars.outputs.package_version }}
-        body: ${{ steps.vars.outputs.changelog }}
   deploy:
     needs: create-tag-and-release
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'master')
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta'
     steps:
     - uses: actions/checkout@master
     - name: Publish to pub.dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 5.0.4-beta.1
+## 5.0.4
 - Update CI to include beta branch.
 
 ## 5.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 5.0.4-beta.1
+- Update CI to include beta branch.
+
 ## 5.0.3
 - Update examples to match latest changes.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![Pub Package](https://img.shields.io/pub/v/artemis.svg)](https://pub.dev/packages/artemis)
 [![GitHub Actions](https://github.com/comigor/artemis/workflows/test/badge.svg)](https://github.com/comigor/artemis/actions)
 
+Check the [**beta**](https://github.com/comigor/artemis/tree/beta) branch for the bleeding edge (and breaking) stuff.
+
 Artemis is a code generator that looks for `schema.graphql` (GraphQL SDL - Schema Definition Language) and `*.graphql` files and builds `.dart` files typing that query, based on the schema. That's similar to what [Apollo](https://github.com/apollographql/apollo-client) does (Artemis is his sister anyway).
 
 ---

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 5.0.4-beta.1
+version: 5.0.4
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 5.0.3
+version: 5.0.4-beta.1
 
 authors:
   - Igor Borges <igor@borges.dev>


### PR DESCRIPTION
From now on, there will be a **beta** branch, shipping `x.x.x-beta.x` dev releases.