### PR TITLE
fix: fromGraphQLToDart handler annotation

### DIFF
--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -251,7 +251,7 @@ Make sure your query is correct and your schema is updated.''');
           .replaceAll(RegExp(r'[<>]'), '');
       final dartTypeSafeStr = dartTypeStr.replaceAll(RegExp(r'[<>]'), '');
       annotation =
-          'JsonKey(fromJson: fromGraphQL${dartTypeStr}ToDart$dartTypeSafeStr, toJson: fromDart${dartTypeSafeStr}ToGraphQL$graphqlTypeSafeStr)';
+          'JsonKey(fromJson: fromGraphQL${graphqlTypeSafeStr}ToDart$dartTypeSafeStr, toJson: fromDart${dartTypeSafeStr}ToGraphQL$graphqlTypeSafeStr)';
     }
   } // On enums
   else if (nextType is EnumTypeDefinitionNode) {


### PR DESCRIPTION
Currently the function names to convert the scalar are not consistent.
For the configuration
```yaml
          scalar_mapping:
            - custom_parser_import: "package:my_app/graphql/custom_scalars.dart"
              graphql_type: timestamptz
              dart_type: DateTime
```
I get the generated code:
```dart
@JsonKey(
      fromJson: fromGraphQLDateTimeToDartDateTime,
      toJson: fromDartDateTimeToGraphQLtimestamptz)
```
I would expect to get:
```dart
      fromJson: fromGraphQLtimestamptzToDartDateTime,
      toJson: fromDartDateTimeToGraphQLtimestamptz
```

I think this is a breaking change, sorry about that.