### PR TITLE
Feat/exception fragment glob and query fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 6.0.9-beta.1
+- Added the exception for the case when `fragment_glob` leads to query files fragments ignore.
+
 ## 6.0.8-beta.1
 - Adapt Artemis to subscriptions and create an example
 

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -29,7 +29,7 @@ LibraryDefinition generateLibrary(
   List<DocumentNode> gqlDocs,
   GeneratorOptions options,
   SchemaMap schemaMap,
-  List<FragmentDefinitionNode> fragmentDefinitionNode,
+  List<FragmentDefinitionNode> fragmentsCommon,
   DocumentNode schema,
 ) {
   final queriesDefinitions = gqlDocs
@@ -39,7 +39,7 @@ LibraryDefinition generateLibrary(
             doc,
             options,
             schemaMap,
-            fragmentDefinitionNode,
+            fragmentsCommon,
           ))
       .toList();
 
@@ -105,8 +105,15 @@ QueryDefinition generateQuery(
 
   final fragments = <FragmentDefinitionNode>[];
 
+  final documentFragments =
+      document.definitions.whereType<FragmentDefinitionNode>();
+
+  if (documentFragments.isNotEmpty && fragmentsCommon.isNotEmpty) {
+    throw FragmentIgnoreException();
+  }
+
   if (fragmentsCommon.isEmpty) {
-    fragments.addAll(document.definitions.whereType<FragmentDefinitionNode>());
+    fragments.addAll(documentFragments);
   } else {
     final fragmentsOperation =
         _extractFragments(operation.selectionSet, fragmentsCommon);

--- a/lib/generator/errors.dart
+++ b/lib/generator/errors.dart
@@ -22,3 +22,16 @@ You may want to:
 
 Classes: ${allClassesNames.join('\n')}''';
 }
+
+/// Define an exception thrown when `fragments_glob` used with the fragments inside query files
+class FragmentIgnoreException implements Exception {
+  /// Define an exception thrown when `fragments_glob` used with the fragments inside query files
+  const FragmentIgnoreException();
+
+  @override
+  String toString() => '''It seems that you are using `fragments_glob` 
+to specify fragments for all queries mapped in `schema_mapping` and using 
+fragments inside query files.
+If `fragments_glob` assigned, fragments defined in inside query files will be ignored.      
+''';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,8 @@
 name: artemis
-version: 6.0.8-beta.1
+version: 6.0.9-beta.1
+
+authors:
+  - Igor Borges <igor@borges.dev>
 
 description: Build dart types from GraphQL schemas and queries (using Introspection Query).
 homepage: https://github.com/comigor/artemis


### PR DESCRIPTION
Added the exception for the case when `fragment_glob` leads to query files fragments ignore.