### PR TITLE
transfer annotations from string to list<string>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 6.0.11-beta.1
+- Convert `ClassProperty` annotation item to `List<String>`.
+
 ## 6.0.10-beta.1
 - Duplication bug fix
 

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -293,7 +293,7 @@ Make sure your query is correct and your schema is updated.''');
   }
 
   // On custom scalars
-  String annotation;
+  final annotations = <String>[];
   if (nextType is ScalarTypeDefinitionNode) {
     final scalar = gql.getSingleScalarMap(context.options, nextType.name.value);
 
@@ -304,8 +304,8 @@ Make sure your query is correct and your schema is updated.''');
               dartType: false, schema: context.schema)
           .replaceAll(RegExp(r'[<>]'), '');
       final dartTypeSafeStr = dartTypeStr.replaceAll(RegExp(r'[<>]'), '');
-      annotation =
-          'JsonKey(fromJson: fromGraphQL${graphqlTypeSafeStr}ToDart$dartTypeSafeStr, toJson: fromDart${dartTypeSafeStr}ToGraphQL$graphqlTypeSafeStr,)';
+      annotations.add(
+          'JsonKey(fromJson: fromGraphQL${graphqlTypeSafeStr}ToDart$dartTypeSafeStr, toJson: fromDart${dartTypeSafeStr}ToGraphQL$graphqlTypeSafeStr,)');
     }
   } // On enums
   else if (nextType is EnumTypeDefinitionNode) {
@@ -314,14 +314,15 @@ Make sure your query is correct and your schema is updated.''');
     }
 
     if (fieldType is! ListTypeNode) {
-      annotation = 'JsonKey(unknownEnumValue: $dartTypeStr.$ARTEMIS_UNKNOWN)';
+      annotations
+          .add('JsonKey(unknownEnumValue: $dartTypeStr.$ARTEMIS_UNKNOWN)');
     }
   }
 
   return ClassProperty(
     type: dartTypeStr,
     name: fieldAlias ?? fieldName,
-    annotation: annotation,
+    annotations: annotations,
     isNonNull: fieldType.isNonNull,
   );
 }
@@ -362,8 +363,10 @@ class _GeneratorVisitor extends RecursiveVisitor {
       _classProperties.add(ClassProperty(
         type: 'String',
         name: 'typeName',
-        annotation: 'JsonKey(name: \'${nextContext.schemaMap.typeNameField}\')',
-        isOverride: true,
+        annotations: [
+          'override',
+          'JsonKey(name: \'${nextContext.schemaMap.typeNameField}\')'
+        ],
         isResolveType: true,
       ));
     }
@@ -467,11 +470,12 @@ class _GeneratorVisitor extends RecursiveVisitor {
     final dartTypeStr = gql.buildTypeString(node.type, context.options,
         dartType: true, replaceLeafWith: nextClassName, schema: context.schema);
 
-    String annotation;
+    final annotations = <String>[];
     if (leafType is EnumTypeDefinitionNode) {
       context.usedEnums.add(leafType.name.value);
       if (leafType is! ListTypeNode) {
-        annotation = 'JsonKey(unknownEnumValue: $dartTypeStr.$ARTEMIS_UNKNOWN)';
+        annotations
+            .add('JsonKey(unknownEnumValue: $dartTypeStr.$ARTEMIS_UNKNOWN)');
       }
     } else if (leafType is InputObjectTypeDefinitionNode) {
       addUsedInputObjectsAndEnums(leafType);
@@ -486,8 +490,8 @@ class _GeneratorVisitor extends RecursiveVisitor {
                 dartType: false, schema: context.schema)
             .replaceAll(RegExp(r'[<>]'), '');
         final dartTypeSafeStr = dartTypeStr.replaceAll(RegExp(r'[<>]'), '');
-        annotation =
-            'JsonKey(fromJson: fromGraphQL${graphqlTypeSafeStr}ToDart$dartTypeSafeStr, toJson: fromDart${dartTypeSafeStr}ToGraphQL$graphqlTypeSafeStr,)';
+        annotations.add(
+            'JsonKey(fromJson: fromGraphQL${graphqlTypeSafeStr}ToDart$dartTypeSafeStr, toJson: fromDart${dartTypeSafeStr}ToGraphQL$graphqlTypeSafeStr,)');
       }
     }
 
@@ -495,7 +499,7 @@ class _GeneratorVisitor extends RecursiveVisitor {
       type: dartTypeStr,
       name: node.variable.name.value,
       isNonNull: node.type.isNonNull,
-      annotation: annotation,
+      annotations: annotations,
     ));
   }
 

--- a/lib/generator/data.dart
+++ b/lib/generator/data.dart
@@ -17,11 +17,8 @@ class ClassProperty extends Equatable with DataPrinter {
   /// The property name.
   final String name;
 
-  /// If property is an override from super class.
-  final bool isOverride;
-
   /// Some other custom annotation.
-  final String annotation;
+  final List<String> annotations;
 
   /// Whether this parameter is required
   final bool isNonNull;
@@ -33,26 +30,26 @@ class ClassProperty extends Equatable with DataPrinter {
   ClassProperty({
     @required this.type,
     @required this.name,
-    this.isOverride = false,
-    this.annotation,
+    this.annotations = const [],
     this.isNonNull = false,
     this.isResolveType = false,
   }) : assert(hasValue(type) && hasValue(name));
+
+  /// If property is an override from super class.
+  bool get isOverride => annotations.contains('override');
 
   /// Creates a copy of [ClassProperty] without modifying the original.
   ClassProperty copyWith({
     String type,
     String name,
-    bool isOverride,
-    String annotation,
+    List<String> annotations,
     bool isNonNull,
     bool isResolveType,
   }) =>
       ClassProperty(
         type: type ?? this.type,
         name: name ?? this.name,
-        isOverride: isOverride ?? this.isOverride,
-        annotation: annotation ?? this.annotation,
+        annotations: annotations ?? this.annotations,
         isNonNull: isNonNull ?? this.isNonNull,
         isResolveType: isResolveType ?? this.isResolveType,
       );
@@ -61,8 +58,7 @@ class ClassProperty extends Equatable with DataPrinter {
   Map<String, Object> get namedProps => {
         'type': type,
         'name': name,
-        'isOverride': isOverride,
-        'annotation': annotation,
+        'annotations': annotations,
         'isNonNull': isNonNull,
         'isResolveType': isResolveType,
       };
@@ -80,14 +76,14 @@ class QueryInput extends Equatable with DataPrinter {
   final bool isNonNull;
 
   /// Some other custom annotation.
-  final String annotation;
+  final List<String> annotations;
 
   /// Instantiate an input parameter.
   QueryInput({
     @required this.type,
     @required this.name,
     this.isNonNull = false,
-    this.annotation,
+    this.annotations = const [],
   }) : assert(hasValue(type) && hasValue(name));
 
   @override
@@ -95,7 +91,7 @@ class QueryInput extends Equatable with DataPrinter {
         'type': type,
         'name': name,
         'isNonNull': isNonNull,
-        'annotation': annotation,
+        'annotations': annotations,
       };
 }
 

--- a/lib/generator/print_helpers.dart
+++ b/lib/generator/print_helpers.dart
@@ -139,16 +139,13 @@ Spec classDefinitionToSpec(
       ..constructors.add(fromJson)
       ..methods.add(toJson)
       ..fields.addAll(definition.properties.map((p) {
-        final annotations = <CodeExpression>[];
-        if (p.isOverride) annotations.add(CodeExpression(Code('override')));
-        if (p.annotation != null) {
-          annotations.add(CodeExpression(Code(p.annotation)));
-        }
         final field = Field(
           (f) => f
             ..name = p.name
             ..type = refer(p.type)
-            ..annotations.addAll(annotations),
+            ..annotations.addAll(
+              p.annotations.map((e) => CodeExpression(Code(e))),
+            ),
         );
         return field;
       })),
@@ -159,10 +156,7 @@ Spec classDefinitionToSpec(
 Spec fragmentClassDefinitionToSpec(FragmentClassDefinition definition) {
   final fields = (definition.properties ?? []).map((p) {
     final lines = <String>[];
-    if (p.isOverride) lines.add('@override');
-    if (p.annotation != null) {
-      lines.add('@${p.annotation}');
-    }
+    lines.addAll(p.annotations.map((e) => '@${e}'));
     lines.add('${p.type} ${p.name};');
     return lines.join('\n');
   });
@@ -225,9 +219,8 @@ Spec generateArgumentClassSpec(QueryDefinition definition) {
             ..name = p.name
             ..type = refer(p.type)
             ..modifier = FieldModifier.final$
-            ..annotations.addAll([
-              if (p.annotation != null) CodeExpression(Code(p.annotation)),
-            ]),
+            ..annotations
+                .addAll(p.annotations.map((e) => CodeExpression(Code(e)))),
         ),
       )),
   );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 6.0.10-beta.1
+version: 6.0.11-beta.1
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/test/generator/print_helpers_test.dart
+++ b/test/generator/print_helpers_test.dart
@@ -75,8 +75,8 @@ void main() {
       final definition =
           FragmentClassDefinition(name: 'FragmentMixin', properties: [
         ClassProperty(type: 'Type', name: 'name'),
-        ClassProperty(type: 'Type', name: 'name', isOverride: true),
-        ClassProperty(type: 'Type', name: 'name', annotation: 'Test'),
+        ClassProperty(type: 'Type', name: 'name', annotations: ['override']),
+        ClassProperty(type: 'Type', name: 'name', annotations: ['Test']),
       ]);
 
       final str = specToString(fragmentClassDefinitionToSpec(definition));
@@ -218,14 +218,11 @@ class AClass with EquatableMixin {
       final definition = ClassDefinition(name: 'AClass', properties: [
         ClassProperty(type: 'Type', name: 'name'),
         ClassProperty(
-            type: 'AnnotedProperty', name: 'name', annotation: 'Hey()'),
+            type: 'AnnotedProperty', name: 'name', annotations: ['Hey()']),
         ClassProperty(
-            type: 'OverridenProperty', name: 'name', isOverride: true),
+            type: 'OverridenProperty', name: 'name', annotations: ['override']),
         ClassProperty(
-            type: 'AllAtOnce',
-            name: 'name',
-            isOverride: true,
-            annotation: 'Ho()'),
+            type: 'AllAtOnce', name: 'name', annotations: ['override', 'Ho()']),
       ]);
 
       final str = specToString(classDefinitionToSpec(definition, []));

--- a/test/query_generator/aliases/alias_on_leaves_test.dart
+++ b/test/query_generator/aliases/alias_on_leaves_test.dart
@@ -59,9 +59,9 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'MyEnum',
                   name: r'thisIsAnEnum',
-                  isOverride: false,
-                  annotation:
-                      r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)',
+                  annotations: [
+                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                  ],
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -74,13 +74,11 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'thisIsAString',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false),
               ClassProperty(
                   type: r'SomeQuery$Response$SomeObject',
                   name: r'o',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],

--- a/test/query_generator/aliases/alias_on_object_test.dart
+++ b/test/query_generator/aliases/alias_on_object_test.dart
@@ -55,11 +55,7 @@ final LibraryDefinition libraryDefinition =
         ClassDefinition(
             name: r'SomeQuery$QueryResponse$SomeObject',
             properties: [
-              ClassProperty(
-                  type: r'String',
-                  name: r'st',
-                  isOverride: false,
-                  isNonNull: false)
+              ClassProperty(type: r'String', name: r'st', isNonNull: false)
             ],
             factoryPossibilities: {},
             typeNameField: r'__typename',
@@ -67,11 +63,7 @@ final LibraryDefinition libraryDefinition =
         ClassDefinition(
             name: r'SomeQuery$QueryResponse$AnotherObject',
             properties: [
-              ClassProperty(
-                  type: r'String',
-                  name: r'str',
-                  isOverride: false,
-                  isNonNull: false)
+              ClassProperty(type: r'String', name: r'str', isNonNull: false)
             ],
             factoryPossibilities: {},
             typeNameField: r'__typename',
@@ -79,20 +71,14 @@ final LibraryDefinition libraryDefinition =
         ClassDefinition(
             name: r'SomeQuery$QueryResponse',
             properties: [
-              ClassProperty(
-                  type: r'String',
-                  name: r's',
-                  isOverride: false,
-                  isNonNull: false),
+              ClassProperty(type: r'String', name: r's', isNonNull: false),
               ClassProperty(
                   type: r'SomeQuery$QueryResponse$SomeObject',
                   name: r'o',
-                  isOverride: false,
                   isNonNull: false),
               ClassProperty(
                   type: r'List<SomeQuery$QueryResponse$AnotherObject>',
                   name: r'anotherObject',
-                  isOverride: false,
                   isNonNull: false)
             ],
             factoryPossibilities: {},

--- a/test/query_generator/ast_schema/field_not_found_mutation_test.dart
+++ b/test/query_generator/ast_schema/field_not_found_mutation_test.dart
@@ -62,13 +62,11 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'id',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false),
               ClassProperty(
                   type: r'String',
                   name: r'message',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -81,7 +79,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'CreateThing$MutationRoot$CreateThingResponse$Thing',
                   name: r'thing',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -94,7 +91,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'CreateThing$MutationRoot$CreateThingResponse',
                   name: r'createThing',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -107,13 +103,11 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'clientId',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false),
               ClassProperty(
                   type: r'String',
                   name: r'message',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],

--- a/test/query_generator/ast_schema/input_types_test.dart
+++ b/test/query_generator/ast_schema/input_types_test.dart
@@ -67,13 +67,11 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'id',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false),
               ClassProperty(
                   type: r'String',
                   name: r'message',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -86,7 +84,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'CreateThing$MutationRoot$CreateThingResponse$Thing',
                   name: r'thing',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -99,7 +96,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'CreateThing$MutationRoot$CreateThingResponse',
                   name: r'createThing',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -112,7 +108,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'id',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false)
             ],
@@ -125,19 +120,16 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'clientId',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false),
               ClassProperty(
                   type: r'String',
                   name: r'message',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false),
               ClassProperty(
                   type: r'List<OtherObjectInput>',
                   name: r'shares',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],

--- a/test/query_generator/ast_schema/missing_schema_test.dart
+++ b/test/query_generator/ast_schema/missing_schema_test.dart
@@ -39,7 +39,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'a',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],

--- a/test/query_generator/enums/enum_duplication_test.dart
+++ b/test/query_generator/enums/enum_duplication_test.dart
@@ -69,9 +69,9 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'MyEnum',
                   name: r'e',
-                  isOverride: false,
-                  annotation:
-                      r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)',
+                  annotations: [
+                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                  ],
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -84,7 +84,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'Custom$Query$Q',
                   name: r'q',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -106,9 +105,9 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'MyEnum',
                   name: r'e',
-                  isOverride: false,
-                  annotation:
-                      r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)',
+                  annotations: [
+                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                  ],
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -121,7 +120,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'List<CustomList$Query$QList>',
                   name: r'qList',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],

--- a/test/query_generator/enums/enum_list_test.dart
+++ b/test/query_generator/enums/enum_list_test.dart
@@ -55,7 +55,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'List<MyEnum>',
                   name: r'le',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -68,7 +67,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'Custom$QueryRoot$QueryResponse',
                   name: r'q',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],

--- a/test/query_generator/enums/filter_enum_test.dart
+++ b/test/query_generator/enums/filter_enum_test.dart
@@ -87,9 +87,9 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'MyEnum',
                   name: r'e',
-                  isOverride: false,
-                  annotation:
-                      r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)',
+                  annotations: [
+                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                  ],
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -102,7 +102,7 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'Custom$QueryRoot$QueryResponse',
                   name: r'q',
-                  isOverride: false,
+                  annotations: [],
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -115,9 +115,9 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'InputInputEnum',
                   name: r'e',
-                  isOverride: false,
-                  annotation:
-                      r'JsonKey(unknownEnumValue: InputInputEnum.ARTEMIS_UNKNOWN)',
+                  annotations: [
+                    r'JsonKey(unknownEnumValue: InputInputEnum.ARTEMIS_UNKNOWN)'
+                  ],
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -130,9 +130,10 @@ final LibraryDefinition libraryDefinition =
             type: r'InputEnum',
             name: r'e',
             isNonNull: true,
-            annotation:
-                r'JsonKey(unknownEnumValue: InputEnum.ARTEMIS_UNKNOWN)'),
-        QueryInput(type: r'Input', name: r'i', isNonNull: true)
+            annotations: [
+              r'JsonKey(unknownEnumValue: InputEnum.ARTEMIS_UNKNOWN)'
+            ]),
+        QueryInput(type: r'Input', name: r'i', isNonNull: true, annotations: [])
       ],
       generateHelpers: false,
       suffix: r'Query')

--- a/test/query_generator/enums/input_enum_test.dart
+++ b/test/query_generator/enums/input_enum_test.dart
@@ -72,23 +72,22 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r's',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false),
               ClassProperty(
                   type: r'MyEnum',
                   name: r'my',
-                  isOverride: false,
-                  annotation:
-                      r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)',
+                  annotations: [
+                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                  ],
                   isNonNull: false,
                   isResolveType: false),
               ClassProperty(
                   type: r'OtherEnum',
                   name: r'other',
-                  isOverride: false,
-                  annotation:
-                      r'JsonKey(unknownEnumValue: OtherEnum.ARTEMIS_UNKNOWN)',
+                  annotations: [
+                    r'JsonKey(unknownEnumValue: OtherEnum.ARTEMIS_UNKNOWN)'
+                  ],
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -101,7 +100,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'Custom$QueryRoot$QueryResponse',
                   name: r'q',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -114,9 +112,9 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'MyEnum',
                   name: r'e',
-                  isOverride: false,
-                  annotation:
-                      r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)',
+                  annotations: [
+                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                  ],
                   isNonNull: true,
                   isResolveType: false)
             ],
@@ -130,7 +128,9 @@ final LibraryDefinition libraryDefinition =
             type: r'OtherEnum',
             name: r'o',
             isNonNull: true,
-            annotation: r'JsonKey(unknownEnumValue: OtherEnum.ARTEMIS_UNKNOWN)')
+            annotations: [
+              r'JsonKey(unknownEnumValue: OtherEnum.ARTEMIS_UNKNOWN)'
+            ])
       ],
       generateHelpers: true,
       suffix: r'Query')

--- a/test/query_generator/enums/query_enum_test.dart
+++ b/test/query_generator/enums/query_enum_test.dart
@@ -56,9 +56,9 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'MyEnum',
                   name: r'e',
-                  isOverride: false,
-                  annotation:
-                      r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)',
+                  annotations: [
+                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                  ],
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -71,7 +71,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'Custom$QueryRoot$QueryResponse',
                   name: r'q',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],

--- a/test/query_generator/forwarder_test.dart
+++ b/test/query_generator/forwarder_test.dart
@@ -57,7 +57,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'a',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],

--- a/test/query_generator/fragments/fragment_duplication_test.dart
+++ b/test/query_generator/fragments/fragment_duplication_test.dart
@@ -92,7 +92,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'PokemonData$Query$Pokemon',
                   name: r'pokemon',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -109,13 +108,11 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'id',
-              isOverride: false,
               isNonNull: true,
               isResolveType: false),
           ClassProperty(
               type: r'PokemonMixin$Evolution',
               name: r'evolution',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false)
         ]),
@@ -123,7 +120,6 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'name',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false)
         ]),
@@ -131,13 +127,11 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'number',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false),
           ClassProperty(
               type: r'String',
               name: r'name',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false)
         ])
@@ -160,7 +154,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'List<AllPokemonsData$Query$AllPokemons>',
                   name: r'allPokemons',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -177,13 +170,11 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'id',
-              isOverride: false,
               isNonNull: true,
               isResolveType: false),
           ClassProperty(
               type: r'PokemonMixin$Evolution',
               name: r'evolution',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false)
         ]),
@@ -191,7 +182,6 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'name',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false)
         ]),
@@ -199,13 +189,11 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'number',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false),
           ClassProperty(
               type: r'String',
               name: r'name',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false)
         ])

--- a/test/query_generator/fragments/fragment_glob_test.dart
+++ b/test/query_generator/fragments/fragment_glob_test.dart
@@ -102,7 +102,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'List<Query$Query$Pokemon$Pokemon>',
                   name: r'evolutions',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -116,7 +115,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'Query$Query$Pokemon',
                   name: r'pokemon',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -139,19 +137,16 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'id',
-              isOverride: false,
               isNonNull: true,
               isResolveType: false),
           ClassProperty(
               type: r'PokemonMixin$PokemonDimension',
               name: r'weight',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false),
           ClassProperty(
               type: r'PokemonMixin$PokemonAttack',
               name: r'attacks',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false)
         ]),
@@ -159,7 +154,6 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'minimum',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false)
         ]),
@@ -173,7 +167,6 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'List<PokemonAttackMixin$Attack>',
               name: r'special',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false)
         ]),
@@ -181,7 +174,6 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'name',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false)
         ])

--- a/test/query_generator/fragments/fragment_on_fragments_test.dart
+++ b/test/query_generator/fragments/fragment_on_fragments_test.dart
@@ -79,7 +79,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'Query$Query$Pokemon',
                   name: r'pokemon',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -96,13 +95,11 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'id',
-              isOverride: false,
               isNonNull: true,
               isResolveType: false),
           ClassProperty(
               type: r'PokemonMixin$Pokemon',
               name: r'evolution',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false)
         ]),
@@ -110,7 +107,6 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'name',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false)
         ]),
@@ -118,13 +114,11 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'number',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false),
           ClassProperty(
               type: r'String',
               name: r'name',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false)
         ])

--- a/test/query_generator/fragments/fragments_multiple_test.dart
+++ b/test/query_generator/fragments/fragments_multiple_test.dart
@@ -89,13 +89,11 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'id',
-              isOverride: false,
               isNonNull: true,
               isResolveType: false),
           ClassProperty(
               type: r'String',
               name: r'name',
-              isOverride: false,
               isNonNull: true,
               isResolveType: false)
         ]),
@@ -103,7 +101,6 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'id',
-              isOverride: false,
               isNonNull: true,
               isResolveType: false)
         ]),
@@ -113,25 +110,21 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'DateTime',
                   name: r'dateFrom',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false),
               ClassProperty(
                   type: r'DateTime',
                   name: r'dateTo',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false),
               ClassProperty(
                   type: r'String',
                   name: r'id',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false),
               ClassProperty(
                   type: r'String',
                   name: r'voyageNumber',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false)
             ],
@@ -144,13 +137,11 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'int',
                   name: r'numberOfReports',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false),
               ClassProperty(
                   type: r'VoyagesData$Query$VoyageList$VoyageDetails$Voyage',
                   name: r'voyage',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false)
             ],
@@ -163,7 +154,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'List<VoyagesData$Query$VoyageList$VoyageDetails>',
                   name: r'voyages',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false)
             ],
@@ -176,7 +166,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'VoyagesData$Query$VoyageList',
                   name: r'voyages',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false)
             ],
@@ -189,13 +178,11 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'int',
                   name: r'limit',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false),
               ClassProperty(
                   type: r'int',
                   name: r'offset',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false)
             ],

--- a/test/query_generator/fragments/fragments_test.dart
+++ b/test/query_generator/fragments/fragments_test.dart
@@ -44,15 +44,10 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r's',
-              isOverride: false,
               isNonNull: false,
               isResolveType: false),
           ClassProperty(
-              type: r'int',
-              name: r'i',
-              isOverride: false,
-              isNonNull: false,
-              isResolveType: false)
+              type: r'int', name: r'i', isNonNull: false, isResolveType: false)
         ]),
         ClassDefinition(
             name: r'SomeQuery$SomeObject',

--- a/test/query_generator/interfaces/interface_fragment_glob_test.dart
+++ b/test/query_generator/interfaces/interface_fragment_glob_test.dart
@@ -102,13 +102,11 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'message',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false),
               ClassProperty(
                   type: r'Custom$Query$NodeById$ChatMessage$User',
                   name: r'user',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false)
             ],
@@ -122,14 +120,15 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'id',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false),
               ClassProperty(
                   type: r'String',
                   name: r'typeName',
-                  isOverride: true,
-                  annotation: r'''JsonKey(name: '__typename')''',
+                  annotations: [
+                    r'override',
+                    r'''JsonKey(name: '__typename')'''
+                  ],
                   isNonNull: false,
                   isResolveType: true)
             ],
@@ -145,7 +144,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'Custom$Query$NodeById',
                   name: r'nodeById',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -156,13 +154,11 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'id',
-              isOverride: false,
               isNonNull: true,
               isResolveType: false),
           ClassProperty(
               type: r'String',
               name: r'username',
-              isOverride: false,
               isNonNull: true,
               isResolveType: false)
         ])

--- a/test/query_generator/interfaces/interface_possible_types_test.dart
+++ b/test/query_generator/interfaces/interface_possible_types_test.dart
@@ -77,7 +77,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'username',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false)
             ],
@@ -91,7 +90,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'message',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false)
             ],
@@ -105,14 +103,15 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'id',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false),
               ClassProperty(
                   type: r'String',
                   name: r'typeName',
-                  isOverride: true,
-                  annotation: r'''JsonKey(name: '__typename')''',
+                  annotations: [
+                    r'override',
+                    r'''JsonKey(name: '__typename')'''
+                  ],
                   isNonNull: false,
                   isResolveType: true)
             ],
@@ -128,7 +127,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'Custom$Query$Node',
                   name: r'nodeById',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],

--- a/test/query_generator/interfaces/interface_test.dart
+++ b/test/query_generator/interfaces/interface_test.dart
@@ -94,13 +94,11 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'message',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false),
               ClassProperty(
                   type: r'Custom$Query$Node$ChatMessage$User',
                   name: r'user',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false)
             ],
@@ -114,14 +112,15 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'id',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false),
               ClassProperty(
                   type: r'String',
                   name: r'typeName',
-                  isOverride: true,
-                  annotation: r'''JsonKey(name: '__typename')''',
+                  annotations: [
+                    r'override',
+                    r'''JsonKey(name: '__typename')'''
+                  ],
                   isNonNull: false,
                   isResolveType: true)
             ],
@@ -137,7 +136,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'Custom$Query$Node',
                   name: r'nodeById',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -148,13 +146,11 @@ final LibraryDefinition libraryDefinition =
           ClassProperty(
               type: r'String',
               name: r'id',
-              isOverride: false,
               isNonNull: true,
               isResolveType: false),
           ClassProperty(
               type: r'String',
               name: r'username',
-              isOverride: false,
               isNonNull: true,
               isResolveType: false)
         ])

--- a/test/query_generator/multiple_queries_test.dart
+++ b/test/query_generator/multiple_queries_test.dart
@@ -38,8 +38,8 @@ final LibraryDefinition libraryDefinition =
         ClassDefinition(
             name: r'SomeQuery$SomeObject',
             properties: [
-              ClassProperty(type: r'String', name: r's', isOverride: false),
-              ClassProperty(type: r'int', name: r'i', isOverride: false)
+              ClassProperty(type: r'String', name: r's'),
+              ClassProperty(type: r'int', name: r'i')
             ],
             typeNameField: r'__typename')
       ],
@@ -50,9 +50,7 @@ final LibraryDefinition libraryDefinition =
       classes: [
         ClassDefinition(
             name: r'AnotherQuery$SomeObject',
-            properties: [
-              ClassProperty(type: r'String', name: r's', isOverride: false)
-            ],
+            properties: [ClassProperty(type: r'String', name: r's')],
             typeNameField: r'__typename')
       ],
       generateHelpers: false)

--- a/test/query_generator/mutations_and_inputs/complex_input_objects_test.dart
+++ b/test/query_generator/mutations_and_inputs/complex_input_objects_test.dart
@@ -61,7 +61,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r's',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -74,7 +73,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'SomeQuery$QueryRoot$SomeObject',
                   name: r'o',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -87,21 +85,19 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r's',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false),
               ClassProperty(
                   type: r'MyEnum',
                   name: r'e',
-                  isOverride: false,
-                  annotation:
-                      r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)',
+                  annotations: [
+                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                  ],
                   isNonNull: false,
                   isResolveType: false),
               ClassProperty(
                   type: r'List<String>',
                   name: r'ls',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],

--- a/test/query_generator/mutations_and_inputs/custom_scalars_on_input_objects_test.dart
+++ b/test/query_generator/mutations_and_inputs/custom_scalars_on_input_objects_test.dart
@@ -68,7 +68,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r's',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -81,7 +80,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'Custom$MutationRoot$MutationResponse',
                   name: r'mut',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -94,9 +92,9 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'MyUuid',
                   name: r'id',
-                  isOverride: false,
-                  annotation:
-                      r'JsonKey(fromJson: fromGraphQLMyUuidToDartMyUuid, toJson: fromDartMyUuidToGraphQLMyUuid,)',
+                  annotations: [
+                    r'JsonKey(fromJson: fromGraphQLMyUuidToDartMyUuid, toJson: fromDartMyUuidToGraphQLMyUuid,)'
+                  ],
                   isNonNull: true,
                   isResolveType: false)
             ],
@@ -110,14 +108,16 @@ final LibraryDefinition libraryDefinition =
             type: r'MyUuid',
             name: r'previousId',
             isNonNull: false,
-            annotation:
-                r'JsonKey(fromJson: fromGraphQLMyUuidToDartMyUuid, toJson: fromDartMyUuidToGraphQLMyUuid,)'),
+            annotations: [
+              r'JsonKey(fromJson: fromGraphQLMyUuidToDartMyUuid, toJson: fromDartMyUuidToGraphQLMyUuid,)'
+            ]),
         QueryInput(
             type: r'List<MyUuid>',
             name: r'listIds',
             isNonNull: false,
-            annotation:
-                r'JsonKey(fromJson: fromGraphQLListMyUuidToDartListMyUuid, toJson: fromDartListMyUuidToGraphQLListMyUuid,)')
+            annotations: [
+              r'JsonKey(fromJson: fromGraphQLListMyUuidToDartListMyUuid, toJson: fromDartListMyUuidToGraphQLListMyUuid,)'
+            ])
       ],
       generateHelpers: true,
       suffix: r'Mutation')

--- a/test/query_generator/mutations_and_inputs/filter_input_objects_test.dart
+++ b/test/query_generator/mutations_and_inputs/filter_input_objects_test.dart
@@ -64,7 +64,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r's',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -77,7 +76,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'SomeQuery$QueryRoot$SomeObject',
                   name: r'o',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -90,7 +88,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'SubInput',
                   name: r's',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -103,7 +100,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r's',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],

--- a/test/query_generator/mutations_and_inputs/input_duplication_test.dart
+++ b/test/query_generator/mutations_and_inputs/input_duplication_test.dart
@@ -67,7 +67,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r's',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -80,7 +79,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'Custom$Mutation$Mut',
                   name: r'mut',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -93,7 +91,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r's',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false)
             ],
@@ -114,7 +111,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r's',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -127,7 +123,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'CustomList$Mutation$MutList',
                   name: r'mutList',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -140,7 +135,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r's',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false)
             ],

--- a/test/query_generator/mutations_and_inputs/mutations_test.dart
+++ b/test/query_generator/mutations_and_inputs/mutations_test.dart
@@ -54,7 +54,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r's',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -67,7 +66,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'Custom$MutationRoot$MutationResponse',
                   name: r'mut',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -80,7 +78,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r's',
-                  isOverride: false,
                   isNonNull: true,
                   isResolveType: false)
             ],

--- a/test/query_generator/query_generator_test.dart
+++ b/test/query_generator/query_generator_test.dart
@@ -46,13 +46,11 @@ void main() {
                           ClassProperty(
                               type: r'String',
                               name: r's',
-                              isOverride: false,
                               isNonNull: false,
                               isResolveType: false),
                           ClassProperty(
                               type: r'int',
                               name: r'i',
-                              isOverride: false,
                               isNonNull: false,
                               isResolveType: false)
                         ],
@@ -127,19 +125,16 @@ class SomeQuery$SomeObject with EquatableMixin {
                           ClassProperty(
                               type: r'String',
                               name: r's',
-                              isOverride: false,
                               isNonNull: false,
                               isResolveType: false),
                           ClassProperty(
                               type: r'int',
                               name: r'i',
-                              isOverride: false,
                               isNonNull: false,
                               isResolveType: false),
                           ClassProperty(
                               type: r'List<int>',
                               name: r'list',
-                              isOverride: false,
                               isNonNull: true,
                               isResolveType: false)
                         ],
@@ -152,7 +147,6 @@ class SomeQuery$SomeObject with EquatableMixin {
                           ClassProperty(
                               type: r'SomeQuery$Query$SomeObject',
                               name: r'someQuery',
-                              isOverride: false,
                               isNonNull: false,
                               isResolveType: false)
                         ],
@@ -358,7 +352,6 @@ class SomeQueryQuery extends GraphQLQuery<SomeQuery$Query, SomeQueryArguments> {
                           ClassProperty(
                               type: r'String',
                               name: r'str',
-                              isOverride: false,
                               isNonNull: false,
                               isResolveType: false)
                         ],
@@ -371,14 +364,12 @@ class SomeQueryQuery extends GraphQLQuery<SomeQuery$Query, SomeQueryArguments> {
                           ClassProperty(
                               type: r'String',
                               name: r'st',
-                              isOverride: false,
                               isNonNull: false,
                               isResolveType: false),
                           ClassProperty(
                               type:
                                   r'List<SomeQuery$Result$SomeObject$AnotherObject>',
                               name: r'ob',
-                              isOverride: false,
                               isNonNull: false,
                               isResolveType: false)
                         ],
@@ -391,13 +382,11 @@ class SomeQueryQuery extends GraphQLQuery<SomeQuery$Query, SomeQueryArguments> {
                           ClassProperty(
                               type: r'String',
                               name: r's',
-                              isOverride: false,
                               isNonNull: false,
                               isResolveType: false),
                           ClassProperty(
                               type: r'SomeQuery$Result$SomeObject',
                               name: r'o',
-                              isOverride: false,
                               isNonNull: false,
                               isResolveType: false)
                         ],
@@ -491,13 +480,11 @@ class SomeQuery$Result with EquatableMixin {
                           ClassProperty(
                               type: r'String',
                               name: r'firstName',
-                              isOverride: false,
                               isNonNull: false,
                               isResolveType: false),
                           ClassProperty(
                               type: r'String',
                               name: r'lastName',
-                              isOverride: false,
                               isNonNull: false,
                               isResolveType: false)
                         ],
@@ -577,13 +564,11 @@ class SomeQuery$Result with EquatableMixin {
                           ClassProperty(
                               type: r'Decimal',
                               name: r'bigDecimal',
-                              isOverride: false,
                               isNonNull: false,
                               isResolveType: false),
                           ClassProperty(
                               type: r'DateTime',
                               name: r'dateTime',
-                              isOverride: false,
                               isNonNull: false,
                               isResolveType: false)
                         ],
@@ -647,7 +632,6 @@ class SomeQuery$SomeObject with EquatableMixin {
                           ClassProperty(
                               type: r'String',
                               name: r's',
-                              isOverride: false,
                               isNonNull: false,
                               isResolveType: false)
                         ],

--- a/test/query_generator/scalars/custom_scalars_test.dart
+++ b/test/query_generator/scalars/custom_scalars_test.dart
@@ -107,11 +107,7 @@ final LibraryDefinition libraryDefinition =
         ClassDefinition(
             name: r'Query$SomeObject',
             properties: [
-              ClassProperty(
-                  type: r'String',
-                  name: r'a',
-                  isOverride: false,
-                  isNonNull: false)
+              ClassProperty(type: r'String', name: r'a', isNonNull: false)
             ],
             factoryPossibilities: {},
             typeNameField: r'__typename',
@@ -132,9 +128,9 @@ final LibraryDefinition libraryDefinitionWithCustomParserFns =
               ClassProperty(
                   type: r'MyDartUuid',
                   name: r'a',
-                  isOverride: false,
-                  annotation:
-                      r'JsonKey(fromJson: fromGraphQLMyUuidToDartMyDartUuid, toJson: fromDartMyDartUuidToGraphQLMyUuid,)',
+                  annotations: [
+                    r'JsonKey(fromJson: fromGraphQLMyUuidToDartMyDartUuid, toJson: fromDartMyDartUuidToGraphQLMyUuid,)'
+                  ],
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -160,9 +156,9 @@ final LibraryDefinition libraryDefinitionWithCustomImports =
               ClassProperty(
                   type: r'MyUuid',
                   name: r'a',
-                  isOverride: false,
-                  annotation:
-                      r'JsonKey(fromJson: fromGraphQLMyUuidToDartMyUuid, toJson: fromDartMyUuidToGraphQLMyUuid,)',
+                  annotations: [
+                    r'JsonKey(fromJson: fromGraphQLMyUuidToDartMyUuid, toJson: fromDartMyUuidToGraphQLMyUuid,)'
+                  ],
                   isNonNull: false,
                   isResolveType: false)
             ],

--- a/test/query_generator/union_types_test.dart
+++ b/test/query_generator/union_types_test.dart
@@ -1,5 +1,4 @@
 import 'package:artemis/generator/data.dart';
-import 'package:gql/language.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
@@ -55,7 +54,6 @@ final String graphQLSchema = '''
 final LibraryDefinition libraryDefinition =
     LibraryDefinition(basename: r'query.graphql', queries: [
   QueryDefinition(
-      document: parseString(query),
       queryName: r'some_query',
       queryType: r'SomeQuery$SomeObject',
       classes: [
@@ -65,7 +63,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'int',
                   name: r'a',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -79,7 +76,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'int',
                   name: r'b',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],
@@ -93,8 +89,10 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'String',
                   name: r'typeName',
-                  isOverride: true,
-                  annotation: r'''JsonKey(name: '__typename')''',
+                  annotations: [
+                    r'override',
+                    r'''JsonKey(name: '__typename')'''
+                  ],
                   isNonNull: false,
                   isResolveType: true)
             ],
@@ -110,7 +108,6 @@ final LibraryDefinition libraryDefinition =
               ClassProperty(
                   type: r'SomeQuery$SomeObject$SomeUnion',
                   name: r'o',
-                  isOverride: false,
                   isNonNull: false,
                   isResolveType: false)
             ],


### PR DESCRIPTION
This PR converts `ClassProperty` annotation item to list.

This is a part of work towards fixing #41 #116 
