### PR TITLE
Change enum casing to camelCase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 6.0.12-beta.1
+**MAJOR BREAKING CHANGE**
+
+- Convert enum casing to camel case.
+
 ## 6.0.11-beta.1
 - Convert `ClassProperty` annotation item to `List<String>`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 6.0.12-beta.1
+## 6.1.0-beta.1
 **MAJOR BREAKING CHANGE**
 
 - Convert enum casing to camel case.

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -471,7 +471,7 @@ class _GeneratorVisitor extends RecursiveVisitor {
     if (leafType is EnumTypeDefinitionNode) {
       context.usedEnums.add(leafType.name.value);
       if (leafType is! ListTypeNode) {
-        annotation = 'JsonKey(unknownEnumValue: $dartTypeStr.$ARTEMIS_UNKNOWN)';
+        annotation = 'JsonKey(unknownEnumValue: $dartTypeStr.${ReCase(ARTEMIS_UNKNOWN).camelCase})';
       }
     } else if (leafType is InputObjectTypeDefinitionNode) {
       addUsedInputObjectsAndEnums(leafType);

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -314,8 +314,8 @@ Make sure your query is correct and your schema is updated.''');
     }
 
     if (fieldType is! ListTypeNode) {
-      annotations
-          .add('JsonKey(unknownEnumValue: $dartTypeStr.${ReCase(ARTEMIS_UNKNOWN).camelCase})');
+      annotations.add(
+          'JsonKey(unknownEnumValue: $dartTypeStr.${ReCase(ARTEMIS_UNKNOWN).camelCase})');
     }
   }
 
@@ -474,8 +474,8 @@ class _GeneratorVisitor extends RecursiveVisitor {
     if (leafType is EnumTypeDefinitionNode) {
       context.usedEnums.add(leafType.name.value);
       if (leafType is! ListTypeNode) {
-        annotations
-            .add('JsonKey(unknownEnumValue: $dartTypeStr.${ReCase(ARTEMIS_UNKNOWN).camelCase})');
+        annotations.add(
+            'JsonKey(unknownEnumValue: $dartTypeStr.${ReCase(ARTEMIS_UNKNOWN).camelCase})');
       }
     } else if (leafType is InputObjectTypeDefinitionNode) {
       addUsedInputObjectsAndEnums(leafType);

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -314,7 +314,7 @@ Make sure your query is correct and your schema is updated.''');
     }
 
     if (fieldType is! ListTypeNode) {
-      annotation = 'JsonKey(unknownEnumValue: $dartTypeStr.$ARTEMIS_UNKNOWN)';
+      annotation = 'JsonKey(unknownEnumValue: $dartTypeStr.${ReCase(ARTEMIS_UNKNOWN).camelCase})';
     }
   }
 

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -599,8 +599,8 @@ class _CanonicalVisitor extends RecursiveVisitor {
 
     enums.add(EnumDefinition(
       name: nextContext.joinedName(),
-      values: node.values.map((eV) => eV.name.value).toList()
-        ..add(ARTEMIS_UNKNOWN),
+      values: node.values.map((eV) => ReCase(eV.name.value).camelCase).toList()
+        ..add(ReCase(ARTEMIS_UNKNOWN).camelCase),
     ));
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 6.0.12-beta.1
+version: 6.1.0-beta.1
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 6.0.11-beta.1
+version: 6.0.12-beta.1
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/test/query_generator/aliases/alias_on_leaves_test.dart
+++ b/test/query_generator/aliases/alias_on_leaves_test.dart
@@ -25,8 +25,8 @@ void main() {
           }
           
           enum MyEnum {
-            A
-            B
+            a
+            b
           }
         ''',
         libraryDefinition: libraryDefinition,
@@ -52,7 +52,7 @@ final LibraryDefinition libraryDefinition =
       queryType: r'SomeQuery$Response',
       classes: [
         EnumDefinition(
-            name: r'MyEnum', values: [r'A', r'B', r'ARTEMIS_UNKNOWN']),
+            name: r'MyEnum', values: [r'a', r'b', r'artemisUnknown']),
         ClassDefinition(
             name: r'SomeQuery$Response$SomeObject',
             properties: [
@@ -60,7 +60,7 @@ final LibraryDefinition libraryDefinition =
                   type: r'MyEnum',
                   name: r'thisIsAnEnum',
                   annotations: [
-                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                    r'JsonKey(unknownEnumValue: MyEnum.artemisUnknown)'
                   ],
                   isNonNull: false,
                   isResolveType: false)
@@ -104,7 +104,7 @@ class SomeQuery$Response$SomeObject with EquatableMixin {
   factory SomeQuery$Response$SomeObject.fromJson(Map<String, dynamic> json) =>
       _$SomeQuery$Response$SomeObjectFromJson(json);
 
-  @JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)
+  @JsonKey(unknownEnumValue: MyEnum.artemisUnknown)
   MyEnum thisIsAnEnum;
 
   @override
@@ -129,8 +129,8 @@ class SomeQuery$Response with EquatableMixin {
 }
 
 enum MyEnum {
-  A,
-  B,
-  ARTEMIS_UNKNOWN,
+  a,
+  b,
+  artemisUnknown,
 }
 ''';

--- a/test/query_generator/enums/enum_duplication_test.dart
+++ b/test/query_generator/enums/enum_duplication_test.dart
@@ -25,8 +25,8 @@ void main() {
           }
           
           enum MyEnum {
-            A
-            B
+            a
+            b
           }
         ''',
         libraryDefinition: libraryDefinition,
@@ -62,7 +62,7 @@ final LibraryDefinition libraryDefinition =
       queryType: r'Custom$Query',
       classes: [
         EnumDefinition(
-            name: r'MyEnum', values: [r'A', r'B', r'ARTEMIS_UNKNOWN']),
+            name: r'MyEnum', values: [r'a', r'b', r'artemisUnknown']),
         ClassDefinition(
             name: r'Custom$Query$Q',
             properties: [
@@ -70,7 +70,7 @@ final LibraryDefinition libraryDefinition =
                   type: r'MyEnum',
                   name: r'e',
                   annotations: [
-                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                    r'JsonKey(unknownEnumValue: MyEnum.artemisUnknown)'
                   ],
                   isNonNull: false,
                   isResolveType: false)
@@ -98,7 +98,7 @@ final LibraryDefinition libraryDefinition =
       queryType: r'CustomList$Query',
       classes: [
         EnumDefinition(
-            name: r'MyEnum', values: [r'A', r'B', r'ARTEMIS_UNKNOWN']),
+            name: r'MyEnum', values: [r'a', r'b', r'artemisUnknown']),
         ClassDefinition(
             name: r'CustomList$Query$QList',
             properties: [
@@ -106,7 +106,7 @@ final LibraryDefinition libraryDefinition =
                   type: r'MyEnum',
                   name: r'e',
                   annotations: [
-                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                    r'JsonKey(unknownEnumValue: MyEnum.artemisUnknown)'
                   ],
                   isNonNull: false,
                   isResolveType: false)
@@ -145,7 +145,7 @@ class Custom$Query$Q with EquatableMixin {
   factory Custom$Query$Q.fromJson(Map<String, dynamic> json) =>
       _$Custom$Query$QFromJson(json);
 
-  @JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)
+  @JsonKey(unknownEnumValue: MyEnum.artemisUnknown)
   MyEnum e;
 
   @override
@@ -174,7 +174,7 @@ class CustomList$Query$QList with EquatableMixin {
   factory CustomList$Query$QList.fromJson(Map<String, dynamic> json) =>
       _$CustomList$Query$QListFromJson(json);
 
-  @JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)
+  @JsonKey(unknownEnumValue: MyEnum.artemisUnknown)
   MyEnum e;
 
   @override
@@ -197,8 +197,8 @@ class CustomList$Query with EquatableMixin {
 }
 
 enum MyEnum {
-  A,
-  B,
-  ARTEMIS_UNKNOWN,
+  a,
+  b,
+  artemisUnknown,
 }
 ''';

--- a/test/query_generator/enums/enum_list_test.dart
+++ b/test/query_generator/enums/enum_list_test.dart
@@ -25,8 +25,8 @@ void main() {
           }
           
           enum MyEnum {
-            A
-            B
+            a
+            b
           }''',
       ),
     );
@@ -48,7 +48,7 @@ final LibraryDefinition libraryDefinition =
       queryType: r'Custom$QueryRoot',
       classes: [
         EnumDefinition(
-            name: r'MyEnum', values: [r'A', r'B', r'artemisUnknown']),
+            name: r'MyEnum', values: [r'a', r'b', r'artemisUnknown']),
         ClassDefinition(
             name: r'Custom$QueryRoot$QueryResponse',
             properties: [
@@ -114,8 +114,8 @@ class Custom$QueryRoot with EquatableMixin {
 }
 
 enum MyEnum {
-  A,
-  B,
+  a,
+  b,
   artemisUnknown,
 }
 ''';

--- a/test/query_generator/enums/enum_list_test.dart
+++ b/test/query_generator/enums/enum_list_test.dart
@@ -48,7 +48,7 @@ final LibraryDefinition libraryDefinition =
       queryType: r'Custom$QueryRoot',
       classes: [
         EnumDefinition(
-            name: r'MyEnum', values: [r'A', r'B', r'ARTEMIS_UNKNOWN']),
+            name: r'MyEnum', values: [r'A', r'B', r'artemisUnknown']),
         ClassDefinition(
             name: r'Custom$QueryRoot$QueryResponse',
             properties: [
@@ -116,6 +116,6 @@ class Custom$QueryRoot with EquatableMixin {
 enum MyEnum {
   A,
   B,
-  ARTEMIS_UNKNOWN,
+  artemisUnknown,
 }
 ''';

--- a/test/query_generator/enums/filter_enum_test.dart
+++ b/test/query_generator/enums/filter_enum_test.dart
@@ -27,18 +27,18 @@ void main() {
           }
 
           enum MyEnum {
-            A
-            B
+            a
+            b
           }
 
           enum InputEnum {
-            C
-            D
+            c
+            d
           }
 
           enum InputInputEnum {
-            E
-            F
+            e
+            f
           }
 
           type UnusedObject {
@@ -50,8 +50,8 @@ void main() {
           }
 
           enum UnusedEnum {
-            G
-            H
+            g
+            h
           }
         ''',
         libraryDefinition: libraryDefinition,
@@ -76,11 +76,11 @@ final LibraryDefinition libraryDefinition =
       queryType: r'Custom$QueryRoot',
       classes: [
         EnumDefinition(
-            name: r'MyEnum', values: [r'A', r'B', r'ARTEMIS_UNKNOWN']),
+            name: r'MyEnum', values: [r'a', r'b', r'artemisUnknown']),
         EnumDefinition(
-            name: r'InputEnum', values: [r'C', r'D', r'ARTEMIS_UNKNOWN']),
+            name: r'InputEnum', values: [r'c', r'd', r'artemisUnknown']),
         EnumDefinition(
-            name: r'InputInputEnum', values: [r'E', r'F', r'ARTEMIS_UNKNOWN']),
+            name: r'InputInputEnum', values: [r'e', r'f', r'artemisUnknown']),
         ClassDefinition(
             name: r'Custom$QueryRoot$QueryResponse',
             properties: [
@@ -88,7 +88,7 @@ final LibraryDefinition libraryDefinition =
                   type: r'MyEnum',
                   name: r'e',
                   annotations: [
-                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                    r'JsonKey(unknownEnumValue: MyEnum.artemisUnknown)'
                   ],
                   isNonNull: false,
                   isResolveType: false)
@@ -116,7 +116,7 @@ final LibraryDefinition libraryDefinition =
                   type: r'InputInputEnum',
                   name: r'e',
                   annotations: [
-                    r'JsonKey(unknownEnumValue: InputInputEnum.ARTEMIS_UNKNOWN)'
+                    r'JsonKey(unknownEnumValue: InputInputEnum.artemisUnknown)'
                   ],
                   isNonNull: false,
                   isResolveType: false)
@@ -131,7 +131,7 @@ final LibraryDefinition libraryDefinition =
             name: r'e',
             isNonNull: true,
             annotations: [
-              r'JsonKey(unknownEnumValue: InputEnum.ARTEMIS_UNKNOWN)'
+              r'JsonKey(unknownEnumValue: InputEnum.artemisUnknown)'
             ]),
         QueryInput(type: r'Input', name: r'i', isNonNull: true, annotations: [])
       ],
@@ -154,7 +154,7 @@ class Custom$QueryRoot$QueryResponse with EquatableMixin {
   factory Custom$QueryRoot$QueryResponse.fromJson(Map<String, dynamic> json) =>
       _$Custom$QueryRoot$QueryResponseFromJson(json);
 
-  @JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)
+  @JsonKey(unknownEnumValue: MyEnum.artemisUnknown)
   MyEnum e;
 
   @override
@@ -182,7 +182,7 @@ class Input with EquatableMixin {
 
   factory Input.fromJson(Map<String, dynamic> json) => _$InputFromJson(json);
 
-  @JsonKey(unknownEnumValue: InputInputEnum.ARTEMIS_UNKNOWN)
+  @JsonKey(unknownEnumValue: InputInputEnum.artemisUnknown)
   InputInputEnum e;
 
   @override
@@ -191,18 +191,18 @@ class Input with EquatableMixin {
 }
 
 enum MyEnum {
-  A,
-  B,
-  ARTEMIS_UNKNOWN,
+  a,
+  b,
+  artemisUnknown,
 }
 enum InputEnum {
-  C,
-  D,
-  ARTEMIS_UNKNOWN,
+  c,
+  d,
+  artemisUnknown,
 }
 enum InputInputEnum {
-  E,
-  F,
-  ARTEMIS_UNKNOWN,
+  e,
+  f,
+  artemisUnknown,
 }
 ''';

--- a/test/query_generator/enums/input_enum_test.dart
+++ b/test/query_generator/enums/input_enum_test.dart
@@ -29,13 +29,13 @@ void main() {
           }
           
           enum MyEnum {
-            A
-            B
+            a
+            b
           }
           
           enum OtherEnum {
-            O1
-            O2
+            o1
+            o2
           }
         ''',
         libraryDefinition: libraryDefinition,
@@ -63,9 +63,9 @@ final LibraryDefinition libraryDefinition =
       queryType: r'Custom$QueryRoot',
       classes: [
         EnumDefinition(
-            name: r'MyEnum', values: [r'A', r'B', r'ARTEMIS_UNKNOWN']),
+            name: r'MyEnum', values: [r'a', r'b', r'artemisUnknown']),
         EnumDefinition(
-            name: r'OtherEnum', values: [r'O1', r'O2', r'ARTEMIS_UNKNOWN']),
+            name: r'OtherEnum', values: [r'o1', r'o2', r'artemisUnknown']),
         ClassDefinition(
             name: r'Custom$QueryRoot$QueryResponse',
             properties: [
@@ -78,7 +78,7 @@ final LibraryDefinition libraryDefinition =
                   type: r'MyEnum',
                   name: r'my',
                   annotations: [
-                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                    r'JsonKey(unknownEnumValue: MyEnum.artemisUnknown)'
                   ],
                   isNonNull: false,
                   isResolveType: false),
@@ -86,7 +86,7 @@ final LibraryDefinition libraryDefinition =
                   type: r'OtherEnum',
                   name: r'other',
                   annotations: [
-                    r'JsonKey(unknownEnumValue: OtherEnum.ARTEMIS_UNKNOWN)'
+                    r'JsonKey(unknownEnumValue: OtherEnum.artemisUnknown)'
                   ],
                   isNonNull: false,
                   isResolveType: false)
@@ -113,7 +113,7 @@ final LibraryDefinition libraryDefinition =
                   type: r'MyEnum',
                   name: r'e',
                   annotations: [
-                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                    r'JsonKey(unknownEnumValue: MyEnum.artemisUnknown)'
                   ],
                   isNonNull: true,
                   isResolveType: false)
@@ -129,7 +129,7 @@ final LibraryDefinition libraryDefinition =
             name: r'o',
             isNonNull: true,
             annotations: [
-              r'JsonKey(unknownEnumValue: OtherEnum.ARTEMIS_UNKNOWN)'
+              r'JsonKey(unknownEnumValue: OtherEnum.artemisUnknown)'
             ])
       ],
       generateHelpers: true,
@@ -154,10 +154,10 @@ class Custom$QueryRoot$QueryResponse with EquatableMixin {
 
   String s;
 
-  @JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)
+  @JsonKey(unknownEnumValue: MyEnum.artemisUnknown)
   MyEnum my;
 
-  @JsonKey(unknownEnumValue: OtherEnum.ARTEMIS_UNKNOWN)
+  @JsonKey(unknownEnumValue: OtherEnum.artemisUnknown)
   OtherEnum other;
 
   @override
@@ -185,7 +185,7 @@ class Input with EquatableMixin {
 
   factory Input.fromJson(Map<String, dynamic> json) => _$InputFromJson(json);
 
-  @JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)
+  @JsonKey(unknownEnumValue: MyEnum.artemisUnknown)
   MyEnum e;
 
   @override
@@ -194,14 +194,14 @@ class Input with EquatableMixin {
 }
 
 enum MyEnum {
-  A,
-  B,
-  ARTEMIS_UNKNOWN,
+  a,
+  b,
+  artemisUnknown,
 }
 enum OtherEnum {
-  O1,
-  O2,
-  ARTEMIS_UNKNOWN,
+  o1,
+  o2,
+  artemisUnknown,
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -213,7 +213,7 @@ class CustomArguments extends JsonSerializable with EquatableMixin {
 
   final Input input;
 
-  @JsonKey(unknownEnumValue: OtherEnum.ARTEMIS_UNKNOWN)
+  @JsonKey(unknownEnumValue: OtherEnum.artemisUnknown)
   final OtherEnum o;
 
   @override

--- a/test/query_generator/enums/query_enum_test.dart
+++ b/test/query_generator/enums/query_enum_test.dart
@@ -23,8 +23,8 @@ void main() {
           }
           
           enum MyEnum {
-            A
-            B
+            a
+            b
           }
         ''',
         libraryDefinition: libraryDefinition,
@@ -49,7 +49,7 @@ final LibraryDefinition libraryDefinition =
       queryType: r'Custom$QueryRoot',
       classes: [
         EnumDefinition(
-            name: r'MyEnum', values: [r'A', r'B', r'ARTEMIS_UNKNOWN']),
+            name: r'MyEnum', values: [r'a', r'b', r'artemisUnknown']),
         ClassDefinition(
             name: r'Custom$QueryRoot$QueryResponse',
             properties: [
@@ -57,7 +57,7 @@ final LibraryDefinition libraryDefinition =
                   type: r'MyEnum',
                   name: r'e',
                   annotations: [
-                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                    r'JsonKey(unknownEnumValue: MyEnum.artemisUnknown)'
                   ],
                   isNonNull: false,
                   isResolveType: false)
@@ -96,7 +96,7 @@ class Custom$QueryRoot$QueryResponse with EquatableMixin {
   factory Custom$QueryRoot$QueryResponse.fromJson(Map<String, dynamic> json) =>
       _$Custom$QueryRoot$QueryResponseFromJson(json);
 
-  @JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)
+  @JsonKey(unknownEnumValue: MyEnum.artemisUnknown)
   MyEnum e;
 
   @override
@@ -119,8 +119,8 @@ class Custom$QueryRoot with EquatableMixin {
 }
 
 enum MyEnum {
-  A,
-  B,
-  ARTEMIS_UNKNOWN,
+  a,
+  b,
+  artemisUnknown,
 }
 ''';

--- a/test/query_generator/mutations_and_inputs/complex_input_objects_test.dart
+++ b/test/query_generator/mutations_and_inputs/complex_input_objects_test.dart
@@ -53,8 +53,7 @@ final LibraryDefinition libraryDefinition =
       queryType: r'SomeQuery$QueryRoot',
       classes: [
         EnumDefinition(
-            name: r'MyEnum',
-            values: [r'value1', r'value2', r'artemisUnknown']),
+            name: r'MyEnum', values: [r'value1', r'value2', r'artemisUnknown']),
         ClassDefinition(
             name: r'SomeQuery$QueryRoot$SomeObject',
             properties: [

--- a/test/query_generator/mutations_and_inputs/complex_input_objects_test.dart
+++ b/test/query_generator/mutations_and_inputs/complex_input_objects_test.dart
@@ -54,7 +54,7 @@ final LibraryDefinition libraryDefinition =
       classes: [
         EnumDefinition(
             name: r'MyEnum',
-            values: [r'value1', r'value2', r'ARTEMIS_UNKNOWN']),
+            values: [r'value1', r'value2', r'artemisUnknown']),
         ClassDefinition(
             name: r'SomeQuery$QueryRoot$SomeObject',
             properties: [
@@ -91,7 +91,7 @@ final LibraryDefinition libraryDefinition =
                   type: r'MyEnum',
                   name: r'e',
                   annotations: [
-                    r'JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)'
+                    r'JsonKey(unknownEnumValue: MyEnum.artemisUnknown)'
                   ],
                   isNonNull: false,
                   isResolveType: false),
@@ -158,7 +158,7 @@ class ComplexInput with EquatableMixin {
 
   String s;
 
-  @JsonKey(unknownEnumValue: MyEnum.ARTEMIS_UNKNOWN)
+  @JsonKey(unknownEnumValue: MyEnum.artemisUnknown)
   MyEnum e;
 
   List<String> ls;
@@ -171,7 +171,7 @@ class ComplexInput with EquatableMixin {
 enum MyEnum {
   value1,
   value2,
-  ARTEMIS_UNKNOWN,
+  artemisUnknown,
 }
 
 @JsonSerializable(explicitToJson: true)


### PR DESCRIPTION
With this pr I added the ReCase function to change enum casing to camelcase.

I did this because camelcase is the standard casing format for enums in dart.

This fixes #122 