### PR TITLE
Support for including __typename

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ targets:
 | - | - | - |
 | `generate_helpers` | `true` | If Artemis should generate query/mutation helper GraphQLQuery subclasses. |
 | `scalar_mapping` | `[]` | Mapping of GraphQL and Dart types. See [Custom scalars](#custom-scalars). |
+| `include_type_name_field` | `false` | When enabled, __typename will be included in generated code (useful for clients which need the typename for caching). |
 | `schema_mapping` | `[]` | Mapping of queries and which schemas they will use for code generation. See [Schema mapping](#schema-mapping). |
 | `fragments_glob` | `null` | Import path to the file implementing fragments for all queries mapped in schema_mapping. If it's assigned, fragments defined in schema_mapping will be ignored. |
 

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -369,6 +369,13 @@ class _GeneratorVisitor extends RecursiveVisitor {
         ],
         isResolveType: true,
       ));
+    } else if (context.schemaMap.includeTypeNameField) {
+      _classProperties.add(ClassProperty(
+          type: 'String',
+          name: 'typeName',
+          annotations: ['JsonKey(name: \'${nextContext.schemaMap.typeNameField}\')'],
+          isNonNull: true,
+          isResolveType: true));
     }
 
     final partOfUnion = nextContext.ofUnion != null;

--- a/lib/schema/options.dart
+++ b/lib/schema/options.dart
@@ -126,6 +126,9 @@ class SchemaMap {
   /// The GraphQL schema string.
   final String schema;
 
+  /// When true, will include typeNameField (eg: __typename) in JSON serialization
+  final bool includeTypeNameField;
+
   /// A [Glob] to find queries files.
   final String queriesGlob;
 
@@ -151,6 +154,7 @@ class SchemaMap {
     this.schema,
     this.queriesGlob,
     this.typeNameField = '__typename',
+    this.includeTypeNameField = false,
     this.namingScheme = NamingScheme.pathedWithTypes,
   });
 

--- a/lib/schema/options.g2.dart
+++ b/lib/schema/options.g2.dart
@@ -69,6 +69,7 @@ SchemaMap _$SchemaMapFromJson(Map<String, dynamic> json) {
     output: json['output'] as String,
     schema: json['schema'] as String,
     queriesGlob: json['queries_glob'] as String,
+    includeTypeNameField: json['include_type_name_field'] as bool ?? false,
     typeNameField: json['type_name_field'] as String ?? '__typename',
     namingScheme: _$enumDecodeNullable(
         _$NamingSchemeEnumMap, json['naming_scheme'],
@@ -80,6 +81,7 @@ Map<String, dynamic> _$SchemaMapToJson(SchemaMap instance) => <String, dynamic>{
       'output': instance.output,
       'schema': instance.schema,
       'queries_glob': instance.queriesGlob,
+      'include_type_name_field': instance.includeTypeNameField,
       'type_name_field': instance.typeNameField,
       'naming_scheme': _$NamingSchemeEnumMap[instance.namingScheme],
     };

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -16,6 +16,7 @@ Future testGenerator({
   @required String generatedFile,
   @required String schema,
   String namingScheme = 'pathedWithTypes',
+  bool includeTypeNameField = false,
   bool generateHelpers = false,
   Map<String, dynamic> builderOptionsMap = const {},
   Map<String, dynamic> sourceAssetsMap = const {},
@@ -32,6 +33,7 @@ Future testGenerator({
         'schema': 'api.schema.graphql',
         'queries_glob': 'queries/**.graphql',
         'output': 'lib/query.graphql.dart',
+        'include_type_name_field': includeTypeNameField,
         'naming_scheme': namingScheme,
       }
     ],

--- a/test/query_generator/query_generator_test.dart
+++ b/test/query_generator/query_generator_test.dart
@@ -21,6 +21,83 @@ void main() {
     });
 
     test(
+        'Should include typeName if enabled',
+            () async => testGenerator(
+            query: 'query some_query { s, i }',
+            includeTypeNameField: true,
+            schema: r'''
+        schema {
+          query: SomeObject
+        }
+  
+        type SomeObject {
+          s: String
+          i: Int
+        }
+      ''',
+            libraryDefinition:
+            LibraryDefinition(basename: r'query.graphql', queries: [
+              QueryDefinition(
+                  queryName: r'some_query',
+                  queryType: r'SomeQuery$SomeObject',
+                  classes: [
+                    ClassDefinition(
+                        name: r'SomeQuery$SomeObject',
+                        properties: [
+                          ClassProperty(
+                              type: r'String',
+                              name: r's',
+                              isNonNull: false,
+                              isResolveType: false),
+                          ClassProperty(
+                              type: r'int',
+                              name: r'i',
+                              isNonNull: false,
+                              isResolveType: false),
+                          ClassProperty(
+                              type: r'String',
+                              name: r'typeName',
+                              annotations: ['JsonKey(name: \'__typename\')'],
+                              isNonNull: true,
+                              isResolveType: true),
+                        ],
+                        factoryPossibilities: {},
+                        typeNameField: r'__typename',
+                        isInput: false)
+                  ],
+                  generateHelpers: false,
+                  suffix: r'Query')
+            ]),
+            generatedFile: r'''// GENERATED CODE - DO NOT MODIFY BY HAND
+
+import 'package:meta/meta.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
+import 'package:gql/ast.dart';
+part 'query.graphql.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class SomeQuery$SomeObject with EquatableMixin {
+  SomeQuery$SomeObject();
+
+  factory SomeQuery$SomeObject.fromJson(Map<String, dynamic> json) =>
+      _$SomeQuery$SomeObjectFromJson(json);
+
+  String s;
+
+  int i;
+
+  @JsonKey(name: '__typename')
+  String typeName;
+
+  @override
+  List<Object> get props => [s, i, typeName];
+  Map<String, dynamic> toJson() => _$SomeQuery$SomeObjectToJson(this);
+}
+''',
+            generateHelpers: false));
+
+    test(
         'A simple query yields simple classes',
         () async => testGenerator(
             query: 'query some_query { s, i }',


### PR DESCRIPTION
Somewhat related to #98, #41 

I'm using flutter graphql which supports cachine and needs the __typename/id returned, this change allows you to opt-in to having it injected instead of being filtered out.