### PR TITLE
Generate __typename mixin

### DIFF
--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -397,9 +397,11 @@ class _GeneratorVisitor extends RecursiveVisitor {
   @override
   void visitFieldNode(FieldNode node) {
     final fieldName = ClassPropertyName(name: node.name.value);
+    final typeNameField = context.schemaMap.typeNameField;
 
-    if (fieldName.name == context.schemaMap.typeNameField) {
-      final typedName = FragmentName(name: 'ArtemisTyped');
+    if (fieldName.name == typeNameField) {
+      final typedName =
+          FragmentName.fromPath(path: [ClassName(name: 'TypeName'), fieldName]);
 
       _mixins.add(typedName);
 
@@ -407,8 +409,8 @@ class _GeneratorVisitor extends RecursiveVisitor {
         context.generatedClasses.add(FragmentClassDefinition(name: typedName, properties: [
           ClassProperty(
             type: TypeName(name: 'String'),
-            name: ClassPropertyName(name: context.schemaMap.typeNameField),
-            annotations: ['override', 'JsonKey(name: \'${context.schemaMap.typeNameField}\')'],
+            name: fieldName,
+            annotations: ['override', 'JsonKey(name: \'${typeNameField}\')'],
             isResolveType: true,
           )
         ]));

--- a/test/query_generator/interfaces/interface_fragment_glob_test.dart
+++ b/test/query_generator/interfaces/interface_fragment_glob_test.dart
@@ -83,7 +83,7 @@ final LibraryDefinition libraryDefinition =
       name: QueryName(name: r'Custom$_Query'),
       operationName: r'custom',
       classes: [
-        FragmentClassDefinition(name: FragmentName(name:'ArtemisTyped'), properties: [
+        FragmentClassDefinition(name: FragmentName(name:'TypeName\$_\$\$typename'), properties: [
           ClassProperty(
             type: TypeName(name: 'String'),
             name: ClassPropertyName(name: '__typename'),
@@ -134,7 +134,7 @@ final LibraryDefinition libraryDefinition =
                   isNonNull: true,
                   isResolveType: false)
             ],
-            mixins: [FragmentName(name: 'ArtemisTyped')],
+            mixins: [FragmentName(name: 'TypeName\$_\$\$typename')],
             factoryPossibilities: {
               r'User': ClassName(name: r'Custom$_Query$_nodeById$_User'),
               r'ChatMessage':
@@ -187,7 +187,7 @@ import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
-mixin ArtemisTypedMixin {
+mixin TypeName$$$typenameMixin {
   @override
   @JsonKey(name: '__typename')
   String $$typename;
@@ -246,7 +246,7 @@ class Custom$Query$NodeById$ChatMessage extends Custom$Query$NodeById
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Query$NodeById with EquatableMixin, ArtemisTypedMixin {
+class Custom$Query$NodeById with EquatableMixin, TypeName$$$typenameMixin {
   Custom$Query$NodeById();
 
   factory Custom$Query$NodeById.fromJson(Map<String, dynamic> json) {

--- a/test/query_generator/interfaces/interface_possible_types_test.dart
+++ b/test/query_generator/interfaces/interface_possible_types_test.dart
@@ -72,7 +72,7 @@ final LibraryDefinition libraryDefinition =
       name: QueryName(name: r'Custom$_Query'),
       operationName: r'custom',
       classes: [
-        FragmentClassDefinition(name: FragmentName(name:'ArtemisTyped'), properties: [
+        FragmentClassDefinition(name: FragmentName(name:'TypeName\$_\$\$typename'), properties: [
           ClassProperty(
             type: TypeName(name: 'String'),
             name: ClassPropertyName(name: '__typename'),
@@ -115,7 +115,7 @@ final LibraryDefinition libraryDefinition =
                   isNonNull: true,
                   isResolveType: false)
             ],
-            mixins: [FragmentName(name: 'ArtemisTyped')],
+            mixins: [FragmentName(name: 'TypeName\$_\$\$typename')],
             factoryPossibilities: {
               r'User': ClassName(name: r'Custom$_Query$_Node$_User'),
               r'ChatMessage':
@@ -154,7 +154,7 @@ import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
-mixin ArtemisTypedMixin {
+mixin TypeName$$$typenameMixin {
   @override
   @JsonKey(name: '__typename')
   String $$typename;
@@ -190,7 +190,7 @@ class Custom$Query$Node$ChatMessage extends Custom$Query$Node
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Query$Node with EquatableMixin, ArtemisTypedMixin {
+class Custom$Query$Node with EquatableMixin, TypeName$$$typenameMixin {
   Custom$Query$Node();
 
   factory Custom$Query$Node.fromJson(Map<String, dynamic> json) {

--- a/test/query_generator/interfaces/interface_test.dart
+++ b/test/query_generator/interfaces/interface_test.dart
@@ -75,7 +75,7 @@ final LibraryDefinition libraryDefinition =
       name: QueryName(name: r'Custom$_Query'),
       operationName: r'custom',
       classes: [
-        FragmentClassDefinition(name: FragmentName(name:'ArtemisTyped'), properties: [
+        FragmentClassDefinition(name: FragmentName(name:'TypeName\$_\$\$typename'), properties: [
           ClassProperty(
             type: TypeName(name: 'String'),
             name: ClassPropertyName(name: '__typename'),
@@ -124,7 +124,7 @@ final LibraryDefinition libraryDefinition =
                   isNonNull: true,
                   isResolveType: false)
             ],
-            mixins: [FragmentName(name: 'ArtemisTyped')],
+            mixins: [FragmentName(name: 'TypeName\$_\$\$typename')],
             factoryPossibilities: {
               r'User': ClassName(name: r'Custom$_Query$_Node$_User'),
               r'ChatMessage':
@@ -177,7 +177,7 @@ import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
-mixin ArtemisTypedMixin {
+mixin TypeName$$$typenameMixin {
   @override
   @JsonKey(name: '__typename')
   String $$typename;
@@ -233,7 +233,7 @@ class Custom$Query$Node$ChatMessage extends Custom$Query$Node
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Query$Node with EquatableMixin, ArtemisTypedMixin {
+class Custom$Query$Node with EquatableMixin, TypeName$$$typenameMixin {
   Custom$Query$Node();
 
   factory Custom$Query$Node.fromJson(Map<String, dynamic> json) {

--- a/test/query_generator/union_types_test.dart
+++ b/test/query_generator/union_types_test.dart
@@ -77,7 +77,7 @@ final LibraryDefinition libraryDefinition =
       name: QueryName(name: r'SomeQuery$_SomeObject'),
       operationName: r'some_query',
       classes: [
-        FragmentClassDefinition(name: FragmentName(name:'ArtemisTyped'), properties: [
+        FragmentClassDefinition(name: FragmentName(name:'TypeName\$_\$\$typename'), properties: [
           ClassProperty(
             type: TypeName(name: 'String'),
             name: ClassPropertyName(name: '__typename'),
@@ -174,7 +174,7 @@ final LibraryDefinition libraryDefinition =
         ClassDefinition(
             name: ClassName(name: r'SomeQuery$_SomeObject$_SomeUnion'),
             properties: [],
-            mixins: [FragmentName(name: 'ArtemisTyped')],
+            mixins: [FragmentName(name: 'TypeName\$_\$\$typename')],
             factoryPossibilities: {
               r'TypeA':
                   ClassName(name: r'SomeQuery$_SomeObject$_SomeUnion$_TypeA'),
@@ -207,7 +207,7 @@ import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
-mixin ArtemisTypedMixin {
+mixin TypeName$$$typenameMixin {
   @override
   @JsonKey(name: '__typename')
   String $$typename;
@@ -278,7 +278,8 @@ class SomeQuery$SomeObject$SomeUnion$TypeB
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$SomeObject$SomeUnion with EquatableMixin, ArtemisTypedMixin {
+class SomeQuery$SomeObject$SomeUnion
+    with EquatableMixin, TypeName$$$typenameMixin {
   SomeQuery$SomeObject$SomeUnion();
 
   factory SomeQuery$SomeObject$SomeUnion.fromJson(Map<String, dynamic> json) {


### PR DESCRIPTION
In order to build an effective caching layer, there needs to be a way to access both a unique identifier (eg: `id`) and the `__typename` in a consistent way. While it is simple to include `id` in a common interface within my schema, `__typename` cannot be consistently determined across generated dart classes and there is no support for a generic fragment that applies to all types.

With this change, I can reference a IdInterfaceMixin and a TypeNameMixin to build a generic caching layer.