### PR TITLE
Fix some analyzer and linter warnings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 6.7.2-beta.1
+- analyzer and linter warnings fix
+
 ## 6.7.1-beta.1
 - uppercase keyword fix
 

--- a/lib/generator/helpers.dart
+++ b/lib/generator/helpers.dart
@@ -130,20 +130,20 @@ extension ExtensionsOnIterable<T, U> on Iterable<T> {
       _removeDuplicatedBy(this, fn);
 }
 
-/// checks if the passed queries contain at least one non nullable field
+/// Checks if the passed queries contain either:
+/// - A [ClassDefinition] that's an input object with at least one non nullable
+///     property.
+/// - A [QueryInput] which is non nullable.
 bool hasNonNullableInput(Iterable<QueryDefinition> queries) {
   for (final query in queries) {
     for (final clazz in query.classes.whereType<ClassDefinition>()) {
-      for (final property in clazz.properties) {
-        if (property.isNonNull) {
-          return true;
-        }
-      }
-    }
-    for (final input in query.inputs) {
-      if (input.isNonNull) {
+      if (clazz.isInput && clazz.properties.any((p) => p.isNonNull)) {
         return true;
       }
+    }
+
+    if (query.inputs.any((i) => i.isNonNull)) {
+      return true;
     }
   }
 

--- a/lib/generator/print_helpers.dart
+++ b/lib/generator/print_helpers.dart
@@ -17,7 +17,7 @@ Spec enumDefinitionToSpec(EnumDefinition definition) =>
 String _enumValueToSpec(EnumValueDefinition value) {
   final annotations = value.annotations
       .map((annotation) => '@$annotation')
-      .followedBy(['@JsonValue("${value.name.name}")']).join(' ');
+      .followedBy(['@JsonValue(\'${value.name.name}\')']).join(' ');
 
   return '$annotations${value.name.namePrintable}, ';
 }

--- a/lib/generator/print_helpers.dart
+++ b/lib/generator/print_helpers.dart
@@ -221,6 +221,7 @@ Spec generateArgumentClassSpec(QueryDefinition definition) {
               ..type = refer('Map<String, dynamic>')
               ..name = 'json',
           ))
+          ..annotations.add(CodeExpression(Code('override')))
           ..body = Code('_\$${definition.className}ArgumentsFromJson(json)'),
       ))
       ..methods.add(Method(
@@ -228,6 +229,7 @@ Spec generateArgumentClassSpec(QueryDefinition definition) {
           ..name = 'toJson'
           ..lambda = true
           ..returns = refer('Map<String, dynamic>')
+          ..annotations.add(CodeExpression(Code('override')))
           ..body = Code('_\$${definition.className}ArgumentsToJson(this)'),
       ))
       ..fields.addAll(definition.inputs.map(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 6.7.1-beta.1
+version: 6.7.2-beta.1
 
 description: Build dart types from GraphQL schemas and queries (using Introspection Query).
 homepage: https://github.com/comigor/artemis

--- a/test/generator/print_helpers_test.dart
+++ b/test/generator/print_helpers_test.dart
@@ -537,6 +537,7 @@ part 'test_query.graphql.g.dart';
 class TestQueryArguments extends JsonSerializable with EquatableMixin {
   TestQueryArguments({this.name});
 
+  @override
   factory TestQueryArguments.fromJson(Map<String, dynamic> json) =>
       _\$TestQueryArgumentsFromJson(json);
 
@@ -544,6 +545,7 @@ class TestQueryArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [name];
+  @override
   Map<String, dynamic> toJson() => _\$TestQueryArgumentsToJson(this);
 }
 
@@ -592,6 +594,7 @@ class TestQueryQuery extends GraphQLQuery<TestQuery, TestQueryArguments> {
 class TestQueryArguments extends JsonSerializable with EquatableMixin {
   TestQueryArguments({this.name});
 
+  @override
   factory TestQueryArguments.fromJson(Map<String, dynamic> json) =>
       _\$TestQueryArgumentsFromJson(json);
 
@@ -599,6 +602,7 @@ class TestQueryArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [name];
+  @override
   Map<String, dynamic> toJson() => _\$TestQueryArgumentsToJson(this);
 }
 ''');

--- a/test/generator/print_helpers_test.dart
+++ b/test/generator/print_helpers_test.dart
@@ -47,13 +47,13 @@ void main() {
       final str = specToString(enumDefinitionToSpec(definition));
 
       expect(str, '''enum Name {
-  @JsonValue("Option")
+  @JsonValue('Option')
   option,
-  @JsonValue("anotherOption")
+  @JsonValue('anotherOption')
   anotherOption,
-  @JsonValue("third_option")
+  @JsonValue('third_option')
   thirdOption,
-  @JsonValue("FORTH_OPTION")
+  @JsonValue('FORTH_OPTION')
   forthOption,
 }
 ''');
@@ -78,9 +78,9 @@ void main() {
       final str = specToString(enumDefinitionToSpec(definition));
 
       expect(str, '''enum Name {
-  @JsonValue("Option")
+  @JsonValue('Option')
   option,
-  @JsonValue("AnotherOption")
+  @JsonValue('AnotherOption')
   anotherOption,
 }
 ''');
@@ -691,7 +691,7 @@ class AClass with EquatableMixin {
 }
 
 enum SomeEnum {
-  @JsonValue("Value")
+  @JsonValue('Value')
   value,
 }
 ''');

--- a/test/query_generator/aliases/alias_on_leaves_test.dart
+++ b/test/query_generator/aliases/alias_on_leaves_test.dart
@@ -141,11 +141,11 @@ class SomeQuery$Response with EquatableMixin {
 }
 
 enum MyEnum {
-  @JsonValue("A")
+  @JsonValue('A')
   a,
-  @JsonValue("B")
+  @JsonValue('B')
   b,
-  @JsonValue("ARTEMIS_UNKNOWN")
+  @JsonValue('ARTEMIS_UNKNOWN')
   artemisUnknown,
 }
 ''';

--- a/test/query_generator/deprecated/deprecated_enum_value_test.dart
+++ b/test/query_generator/deprecated/deprecated_enum_value_test.dart
@@ -113,13 +113,13 @@ class SomeQuery$QueryResponse with EquatableMixin {
 
 enum StarWarsMovies {
   @Deprecated('deprecated movie')
-  @JsonValue("NEW_HOPE")
+  @JsonValue('NEW_HOPE')
   newHope,
-  @JsonValue("EMPIRE")
+  @JsonValue('EMPIRE')
   empire,
-  @JsonValue("JEDI")
+  @JsonValue('JEDI')
   jedi,
-  @JsonValue("ARTEMIS_UNKNOWN")
+  @JsonValue('ARTEMIS_UNKNOWN')
   artemisUnknown,
 }
 ''';

--- a/test/query_generator/deprecated/deprecated_input_object_field_test.dart
+++ b/test/query_generator/deprecated/deprecated_input_object_field_test.dart
@@ -172,6 +172,7 @@ class Input with EquatableMixin {
 class CustomArguments extends JsonSerializable with EquatableMixin {
   CustomArguments({@required this.input});
 
+  @override
   factory CustomArguments.fromJson(Map<String, dynamic> json) =>
       _$CustomArgumentsFromJson(json);
 
@@ -179,6 +180,7 @@ class CustomArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [input];
+  @override
   Map<String, dynamic> toJson() => _$CustomArgumentsToJson(this);
 }
 

--- a/test/query_generator/enums/enum_duplication_test.dart
+++ b/test/query_generator/enums/enum_duplication_test.dart
@@ -220,11 +220,11 @@ class CustomList$Query with EquatableMixin {
 }
 
 enum MyEnum {
-  @JsonValue("A")
+  @JsonValue('A')
   a,
-  @JsonValue("B")
+  @JsonValue('B')
   b,
-  @JsonValue("ARTEMIS_UNKNOWN")
+  @JsonValue('ARTEMIS_UNKNOWN')
   artemisUnknown,
 }
 ''';

--- a/test/query_generator/enums/enum_list_test.dart
+++ b/test/query_generator/enums/enum_list_test.dart
@@ -127,11 +127,11 @@ class Custom$QueryRoot with EquatableMixin {
 }
 
 enum MyEnum {
-  @JsonValue("A")
+  @JsonValue('A')
   a,
-  @JsonValue("B")
+  @JsonValue('B')
   b,
-  @JsonValue("ARTEMIS_UNKNOWN")
+  @JsonValue('ARTEMIS_UNKNOWN')
   artemisUnknown,
 }
 ''';

--- a/test/query_generator/enums/filter_enum_test.dart
+++ b/test/query_generator/enums/filter_enum_test.dart
@@ -209,31 +209,31 @@ class Input with EquatableMixin {
 }
 
 enum MyEnum {
-  @JsonValue("A")
+  @JsonValue('A')
   a,
-  @JsonValue("B")
+  @JsonValue('B')
   b,
-  @JsonValue("ARTEMIS_UNKNOWN")
+  @JsonValue('ARTEMIS_UNKNOWN')
   artemisUnknown,
 }
 enum InputEnum {
-  @JsonValue("C")
+  @JsonValue('C')
   c,
-  @JsonValue("D")
+  @JsonValue('D')
   d,
-  @JsonValue("ARTEMIS_UNKNOWN")
+  @JsonValue('ARTEMIS_UNKNOWN')
   artemisUnknown,
 }
 enum $InputInputEnum {
-  @JsonValue("_E")
+  @JsonValue('_E')
   $e,
-  @JsonValue("_F")
+  @JsonValue('_F')
   $f,
-  @JsonValue("_new")
+  @JsonValue('_new')
   $new,
-  @JsonValue("new")
+  @JsonValue('new')
   kw$new,
-  @JsonValue("ARTEMIS_UNKNOWN")
+  @JsonValue('ARTEMIS_UNKNOWN')
   artemisUnknown,
 }
 ''';

--- a/test/query_generator/enums/input_enum_list_test.dart
+++ b/test/query_generator/enums/input_enum_list_test.dart
@@ -112,7 +112,6 @@ final LibraryDefinition libraryDefinition =
 
 const generatedFile = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 
-import 'package:meta/meta.dart';
 import 'package:artemis/artemis.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:equatable/equatable.dart';
@@ -154,11 +153,11 @@ class BrowseArticles$Query with EquatableMixin {
 }
 
 enum ArticleType {
-  @JsonValue("NEWS")
+  @JsonValue('NEWS')
   news,
-  @JsonValue("TUTORIAL")
+  @JsonValue('TUTORIAL')
   tutorial,
-  @JsonValue("ARTEMIS_UNKNOWN")
+  @JsonValue('ARTEMIS_UNKNOWN')
   artemisUnknown,
 }
 
@@ -166,6 +165,7 @@ enum ArticleType {
 class BrowseArticlesArguments extends JsonSerializable with EquatableMixin {
   BrowseArticlesArguments({this.article_type_in});
 
+  @override
   factory BrowseArticlesArguments.fromJson(Map<String, dynamic> json) =>
       _$BrowseArticlesArgumentsFromJson(json);
 
@@ -173,6 +173,7 @@ class BrowseArticlesArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [article_type_in];
+  @override
   Map<String, dynamic> toJson() => _$BrowseArticlesArgumentsToJson(this);
 }
 

--- a/test/query_generator/enums/input_enum_test.dart
+++ b/test/query_generator/enums/input_enum_test.dart
@@ -240,6 +240,7 @@ enum OtherEnum {
 class CustomArguments extends JsonSerializable with EquatableMixin {
   CustomArguments({@required this.input, @required this.o});
 
+  @override
   factory CustomArguments.fromJson(Map<String, dynamic> json) =>
       _$CustomArgumentsFromJson(json);
 
@@ -250,6 +251,7 @@ class CustomArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [input, o];
+  @override
   Map<String, dynamic> toJson() => _$CustomArgumentsToJson(this);
 }
 

--- a/test/query_generator/enums/input_enum_test.dart
+++ b/test/query_generator/enums/input_enum_test.dart
@@ -220,19 +220,19 @@ class Input with EquatableMixin {
 }
 
 enum MyEnum {
-  @JsonValue("A")
+  @JsonValue('A')
   a,
-  @JsonValue("B")
+  @JsonValue('B')
   b,
-  @JsonValue("ARTEMIS_UNKNOWN")
+  @JsonValue('ARTEMIS_UNKNOWN')
   artemisUnknown,
 }
 enum OtherEnum {
-  @JsonValue("O1")
+  @JsonValue('O1')
   o1,
-  @JsonValue("O2")
+  @JsonValue('O2')
   o2,
-  @JsonValue("ARTEMIS_UNKNOWN")
+  @JsonValue('ARTEMIS_UNKNOWN')
   artemisUnknown,
 }
 

--- a/test/query_generator/enums/query_enum_test.dart
+++ b/test/query_generator/enums/query_enum_test.dart
@@ -127,13 +127,13 @@ class Custom$QueryRoot with EquatableMixin {
 }
 
 enum MyEnum {
-  @JsonValue("A")
+  @JsonValue('A')
   a,
-  @JsonValue("B")
+  @JsonValue('B')
   b,
-  @JsonValue("IN")
+  @JsonValue('IN')
   kw$IN,
-  @JsonValue("ARTEMIS_UNKNOWN")
+  @JsonValue('ARTEMIS_UNKNOWN')
   artemisUnknown,
 }
 ''';

--- a/test/query_generator/fragments/fragments_multiple_test.dart
+++ b/test/query_generator/fragments/fragments_multiple_test.dart
@@ -326,6 +326,7 @@ class PaginationInput with EquatableMixin {
 class VoyagesDataArguments extends JsonSerializable with EquatableMixin {
   VoyagesDataArguments({@required this.input});
 
+  @override
   factory VoyagesDataArguments.fromJson(Map<String, dynamic> json) =>
       _$VoyagesDataArgumentsFromJson(json);
 
@@ -333,6 +334,7 @@ class VoyagesDataArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [input];
+  @override
   Map<String, dynamic> toJson() => _$VoyagesDataArgumentsToJson(this);
 }
 

--- a/test/query_generator/multiple_operations_per_file_test.dart
+++ b/test/query_generator/multiple_operations_per_file_test.dart
@@ -255,6 +255,7 @@ class QueData$Query with EquatableMixin {
 class MutDataArguments extends JsonSerializable with EquatableMixin {
   MutDataArguments({@required this.input});
 
+  @override
   factory MutDataArguments.fromJson(Map<String, dynamic> json) =>
       _$MutDataArgumentsFromJson(json);
 
@@ -262,6 +263,7 @@ class MutDataArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [input];
+  @override
   Map<String, dynamic> toJson() => _$MutDataArgumentsToJson(this);
 }
 
@@ -381,6 +383,7 @@ class MutDataMutation extends GraphQLQuery<MutData$Mutation, MutDataArguments> {
 class QueDataArguments extends JsonSerializable with EquatableMixin {
   QueDataArguments({@required this.intsNonNullable, this.stringNullable});
 
+  @override
   factory QueDataArguments.fromJson(Map<String, dynamic> json) =>
       _$QueDataArgumentsFromJson(json);
 
@@ -390,6 +393,7 @@ class QueDataArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [intsNonNullable, stringNullable];
+  @override
   Map<String, dynamic> toJson() => _$QueDataArgumentsToJson(this);
 }
 

--- a/test/query_generator/mutations_and_inputs/complex_input_objects_test.dart
+++ b/test/query_generator/mutations_and_inputs/complex_input_objects_test.dart
@@ -203,6 +203,7 @@ enum MyEnum {
 class SomeQueryArguments extends JsonSerializable with EquatableMixin {
   SomeQueryArguments({@required this.filter});
 
+  @override
   factory SomeQueryArguments.fromJson(Map<String, dynamic> json) =>
       _$SomeQueryArgumentsFromJson(json);
 
@@ -210,6 +211,7 @@ class SomeQueryArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [filter];
+  @override
   Map<String, dynamic> toJson() => _$SomeQueryArgumentsToJson(this);
 }
 

--- a/test/query_generator/mutations_and_inputs/complex_input_objects_test.dart
+++ b/test/query_generator/mutations_and_inputs/complex_input_objects_test.dart
@@ -191,11 +191,11 @@ class ComplexInput with EquatableMixin {
 }
 
 enum MyEnum {
-  @JsonValue("value1")
+  @JsonValue('value1')
   value1,
-  @JsonValue("value2")
+  @JsonValue('value2')
   value2,
-  @JsonValue("ARTEMIS_UNKNOWN")
+  @JsonValue('ARTEMIS_UNKNOWN')
   artemisUnknown,
 }
 

--- a/test/query_generator/mutations_and_inputs/custom_scalars_on_input_objects_test.dart
+++ b/test/query_generator/mutations_and_inputs/custom_scalars_on_input_objects_test.dart
@@ -194,6 +194,7 @@ class Input with EquatableMixin {
 class CustomArguments extends JsonSerializable with EquatableMixin {
   CustomArguments({@required this.input, this.previousId, this.listIds});
 
+  @override
   factory CustomArguments.fromJson(Map<String, dynamic> json) =>
       _$CustomArgumentsFromJson(json);
 
@@ -213,6 +214,7 @@ class CustomArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [input, previousId, listIds];
+  @override
   Map<String, dynamic> toJson() => _$CustomArgumentsToJson(this);
 }
 

--- a/test/query_generator/mutations_and_inputs/filter_input_objects_test.dart
+++ b/test/query_generator/mutations_and_inputs/filter_input_objects_test.dart
@@ -187,6 +187,7 @@ class SubInput with EquatableMixin {
 class SomeQueryArguments extends JsonSerializable with EquatableMixin {
   SomeQueryArguments({@required this.input});
 
+  @override
   factory SomeQueryArguments.fromJson(Map<String, dynamic> json) =>
       _$SomeQueryArgumentsFromJson(json);
 
@@ -194,6 +195,7 @@ class SomeQueryArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [input];
+  @override
   Map<String, dynamic> toJson() => _$SomeQueryArgumentsToJson(this);
 }
 

--- a/test/query_generator/mutations_and_inputs/input_duplication_test.dart
+++ b/test/query_generator/mutations_and_inputs/input_duplication_test.dart
@@ -241,6 +241,7 @@ class CustomList$Mutation with EquatableMixin {
 class CustomArguments extends JsonSerializable with EquatableMixin {
   CustomArguments({@required this.input});
 
+  @override
   factory CustomArguments.fromJson(Map<String, dynamic> json) =>
       _$CustomArgumentsFromJson(json);
 
@@ -248,6 +249,7 @@ class CustomArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [input];
+  @override
   Map<String, dynamic> toJson() => _$CustomArgumentsToJson(this);
 }
 
@@ -306,6 +308,7 @@ class CustomMutation extends GraphQLQuery<Custom$Mutation, CustomArguments> {
 class CustomListArguments extends JsonSerializable with EquatableMixin {
   CustomListArguments({@required this.input});
 
+  @override
   factory CustomListArguments.fromJson(Map<String, dynamic> json) =>
       _$CustomListArgumentsFromJson(json);
 
@@ -313,6 +316,7 @@ class CustomListArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [input];
+  @override
   Map<String, dynamic> toJson() => _$CustomListArgumentsToJson(this);
 }
 

--- a/test/query_generator/mutations_and_inputs/mutations_test.dart
+++ b/test/query_generator/mutations_and_inputs/mutations_test.dart
@@ -273,6 +273,7 @@ class $Input with EquatableMixin {
 class CustomArguments extends JsonSerializable with EquatableMixin {
   CustomArguments({@required this.input});
 
+  @override
   factory CustomArguments.fromJson(Map<String, dynamic> json) =>
       _$CustomArgumentsFromJson(json);
 
@@ -280,6 +281,7 @@ class CustomArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [input];
+  @override
   Map<String, dynamic> toJson() => _$CustomArgumentsToJson(this);
 }
 
@@ -339,6 +341,7 @@ class CustomMutation
 class $customArguments extends JsonSerializable with EquatableMixin {
   $customArguments({@required this.input});
 
+  @override
   factory $customArguments.fromJson(Map<String, dynamic> json) =>
       _$$customArgumentsFromJson(json);
 
@@ -346,6 +349,7 @@ class $customArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [input];
+  @override
   Map<String, dynamic> toJson() => _$$customArgumentsToJson(this);
 }
 

--- a/test/query_generator/naming/casing_conversion_test.dart
+++ b/test/query_generator/naming/casing_conversion_test.dart
@@ -307,15 +307,15 @@ class Input with EquatableMixin {
 }
 
 enum MyEnum {
-  @JsonValue("camelCase")
+  @JsonValue('camelCase')
   camelCase,
-  @JsonValue("PascalCase")
+  @JsonValue('PascalCase')
   pascalCase,
-  @JsonValue("snake_case")
+  @JsonValue('snake_case')
   snakeCase,
-  @JsonValue("SCREAMING_SNAKE_CASE")
+  @JsonValue('SCREAMING_SNAKE_CASE')
   screamingSnakeCase,
-  @JsonValue("ARTEMIS_UNKNOWN")
+  @JsonValue('ARTEMIS_UNKNOWN')
   artemisUnknown,
 }
 
@@ -323,6 +323,7 @@ enum MyEnum {
 class SomeQueryArguments extends JsonSerializable with EquatableMixin {
   SomeQueryArguments({@required this.filter});
 
+  @override
   factory SomeQueryArguments.fromJson(Map<String, dynamic> json) =>
       _$SomeQueryArgumentsFromJson(json);
 
@@ -330,6 +331,7 @@ class SomeQueryArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [filter];
+  @override
   Map<String, dynamic> toJson() => _$SomeQueryArgumentsToJson(this);
 }
 

--- a/test/query_generator/query_generator_test.dart
+++ b/test/query_generator/query_generator_test.dart
@@ -215,6 +215,7 @@ class SomeQuery$Query with EquatableMixin {
 class SomeQueryArguments extends JsonSerializable with EquatableMixin {
   SomeQueryArguments({@required this.intsNonNullable, this.stringNullable});
 
+  @override
   factory SomeQueryArguments.fromJson(Map<String, dynamic> json) =>
       _$SomeQueryArgumentsFromJson(json);
 
@@ -224,6 +225,7 @@ class SomeQueryArguments extends JsonSerializable with EquatableMixin {
 
   @override
   List<Object> get props => [intsNonNullable, stringNullable];
+  @override
   Map<String, dynamic> toJson() => _$SomeQueryArgumentsToJson(this);
 }
 


### PR DESCRIPTION
**Why?**
---
We had just cleaned up our project to contain zero analyzer and linter warnings after updating to the latest version of Flutter. After running code generation for some queries and mutations that we started porting over to utilize Artemis, we introduced quite a bit of analyzer and linter warnings. This didn't feel good, especially because these seemed pretty minor.

In addition, our CI caught that some files that needed formatting, and they were from the library forwarder generated files.

This meant we'd have to run code generation, and then clean up some of these files manually which felt counterintuitive, especially seeing as we run other code generation that's not related to GQL. Then we'd have to do this every time we ran code generation.

![Screen Shot 2020-08-13 at 4 08 02 PM](https://user-images.githubusercontent.com/3655571/90181978-3fd91d80-dd7f-11ea-9905-f6164085cef2.png)

**What?**
---
Separating this out into three issues:

1. `Annotate overridden members.`:
It looked like we can add the annotation to the `fromJson` and `toJson` methods that override the `JsonSerializable`'s implementation in `generateArgumentClassSpec`.

2. `Unused import: 'package:meta/meta.dart'. Try removing the import directive.`:
This one looked a little trickier. After looking, it looks like we add the `required` annotation only if there is a `ClassDefinition` that's an input _and_ contains a non-null property, or if it's a mutation argument class with a non-null property. 
The gap here looked like we checked if the `ClassDefinition` was an input class when adding the annotation, but when checking to see if we should add the `meta` package (required for that annotation) we didn't check if it was an input class. 

3. Use single quotes instead of double quotes in `JsonValue`.


## Notes

I went ahead and bumped the version, and added a changelog entry for this version. Let me know if you'd like me to revert that if you intend to bundle this up with another change.

--- 
Let me know if you'd like to see any other changes, or if there are some hidden side-effects these changes would have. These changes seemed pretty straightforward and low-impact.
