### PR TITLE
Fixed ignore_for_file documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 6.12.2-beta.1
+- Fixed `ignore_for_file` documentation.
+
 ## 6.12.1-beta.1
 - Added `ignore_for_file` option to ignore linter rules on generated files.
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ targets:
 | `scalar_mapping` | `[]` | Mapping of GraphQL and Dart types. See [Custom scalars](#custom-scalars). |
 | `schema_mapping` | `[]` | Mapping of queries and which schemas they will use for code generation. See [Schema mapping](#schema-mapping). |
 | `fragments_glob` | `null` | Import path to the file implementing fragments for all queries mapped in schema_mapping. If it's assigned, fragments defined in schema_mapping will be ignored. |
+| `ignore_for_file` | `[]`  | The linter rules to ignore for artemis generated files. |
 
 It's important to remember that, by default, [build](https://github.com/dart-lang/build) will follow [Dart's package layout conventions](https://dart.dev/tools/pub/package-layout), meaning that only some folders will be considered to parse the input files. So, if you want to reference files from a folder other than `lib/`, make sure you've included it on `sources`:
 ```yaml
@@ -126,7 +127,6 @@ Each `SchemaMap` is configured this way:
 | `queries_glob` |  | Glob that selects all query files to be used with this schema. |
 | `naming_scheme` | `pathedWithTypes` | The naming scheme to be used on generated classes names. `pathedWithTypes` is the default for retrocompatibility, where the names of previous types are used as prefix of the next class. This can generate duplication on certain schemas. With `pathedWithFields`, the names of previous fields are used as prefix of the next class and with `simple`, only the actual GraphQL class nameis considered. | 
 | `type_name_field` | `__typename` | The name of the field used to differentiatiate interfaces and union types (commonly `__typename` or `__resolveType`). Note that `__typename` field are not added automatically to the query. If you want interface/union type resolution, you need to manually add it there. |
-| `ignore_for_file` | `[]`  | The linter rules to ignore for artemis generated files. |
 
 See [examples](./example) for more information and configuration options.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 6.12.1-beta.1
+version: 6.12.2-beta.1
 
 description: Build dart types from GraphQL schemas and queries (using Introspection Query).
 homepage: https://github.com/comigor/artemis


### PR DESCRIPTION
Hi, @vasilich6107 @comigor, it's me again.
By looking to the recently merged PR #210, just realized that the ignore_for_file option in README wasn't at the right place.
Just wanted to fixed to avoid new issues. 
Sorry for that.