### PR TITLE
Update equatable version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The generated code uses the following packages in run-time:
 dependencies:
   artemis: '>=5.0.0 <6.0.0' # only if you're using ArtemisClient!
   json_serializable: ^3.0.0
-  equatable: ^0.6.1
+  equatable: ^1.0.1
   meta: '>=1.0.0 <2.0.0' # only if you have non nullable fields
   gql: '>=0.7.3 <1.0.0'
 ```


### PR DESCRIPTION
got error
```
Because graphql_artemis depends on artemis ^5.0.0 which depends on equatable ^1.0.1, equatable ^1.0.1 is required.
So, because graphql_artemis depends on equatable ^0.6.1, version solving failed.
pub get failed (1; So, because graphql_artemis depends on equatable ^0.6.1, version solving failed.)
```
https://github.com/comigor/artemis/blob/master/pubspec.yaml#L17