### PR TITLE
Allow for auto generated response and inputs to extend JsonSerializable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 6.20.1-beta.1
+- Allow for auto generated response and inputs to extend JsonSerializable
+
 ## 6.19.3-beta.1
 - bugfix of append typename - common fragments
 

--- a/lib/generator/print_helpers.dart
+++ b/lib/generator/print_helpers.dart
@@ -134,7 +134,7 @@ Spec classDefinitionToSpec(
       ..methods.add(_propsMethod('[${props.join(',')}]'))
       ..extend = definition.extension != null
           ? refer(definition.extension.namePrintable)
-          : null
+          : refer('JsonSerializable')
       ..implements.addAll(definition.implementations.map((i) => refer(i)))
       ..constructors.add(Constructor((b) {
         if (definition.isInput) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 6.19.3-beta.1
+version: 6.20.1-beta.1
 
 description: Build dart types from GraphQL schemas and queries (using Introspection Query).
 homepage: https://github.com/comigor/artemis

--- a/test/generator/print_helpers_test.dart
+++ b/test/generator/print_helpers_test.dart
@@ -150,7 +150,7 @@ void main() {
       final str = specToString(classDefinitionToSpec(definition, [], []));
 
       expect(str, '''@JsonSerializable(explicitToJson: true)
-class AClass with EquatableMixin {
+class AClass extends JsonSerializable with EquatableMixin {
   AClass();
 
   factory AClass.fromJson(Map<String, dynamic> json) => _\$AClassFromJson(json);
@@ -199,7 +199,7 @@ class AClass extends AnotherClass with EquatableMixin {
       final str = specToString(classDefinitionToSpec(definition, [], []));
 
       expect(str, r'''@JsonSerializable(explicitToJson: true)
-class AClass with EquatableMixin {
+class AClass extends JsonSerializable with EquatableMixin {
   AClass();
 
   factory AClass.fromJson(Map<String, dynamic> json) {
@@ -243,7 +243,7 @@ class AClass with EquatableMixin {
       final str = specToString(classDefinitionToSpec(definition, [], []));
 
       expect(str, '''@JsonSerializable(explicitToJson: true)
-class AClass with EquatableMixin {
+class AClass extends JsonSerializable with EquatableMixin {
   AClass();
 
   factory AClass.fromJson(Map<String, dynamic> json) => _\$AClassFromJson(json);
@@ -284,7 +284,7 @@ class AClass with EquatableMixin {
       final str = specToString(classDefinitionToSpec(definition, [], []));
 
       expect(str, '''@JsonSerializable(explicitToJson: true)
-class AClass with EquatableMixin {
+class AClass extends JsonSerializable with EquatableMixin {
   AClass();
 
   factory AClass.fromJson(Map<String, dynamic> json) => _\$AClassFromJson(json);
@@ -327,7 +327,7 @@ class AClass with EquatableMixin {
       ], []));
 
       expect(str, '''@JsonSerializable(explicitToJson: true)
-class AClass with EquatableMixin, FragmentMixin {
+class AClass extends JsonSerializable with EquatableMixin, FragmentMixin {
   AClass();
 
   factory AClass.fromJson(Map<String, dynamic> json) => _\$AClassFromJson(json);
@@ -358,7 +358,7 @@ class AClass with EquatableMixin, FragmentMixin {
       final str = specToString(classDefinitionToSpec(definition, [], []));
 
       expect(str, '''@JsonSerializable(explicitToJson: true)
-class AClass with EquatableMixin {
+class AClass extends JsonSerializable with EquatableMixin {
   AClass({this.name, @required this.anotherName});
 
   factory AClass.fromJson(Map<String, dynamic> json) => _\$AClassFromJson(json);
@@ -686,7 +686,7 @@ import 'package:gql/ast.dart';
 part 'test_query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class AClass with EquatableMixin {
+class AClass extends JsonSerializable with EquatableMixin {
   AClass();
 
   factory AClass.fromJson(Map<String, dynamic> json) => _\$AClassFromJson(json);

--- a/test/query_generator/aliases/alias_on_leaves_test.dart
+++ b/test/query_generator/aliases/alias_on_leaves_test.dart
@@ -110,7 +110,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$Response$SomeObject with EquatableMixin {
+class SomeQuery$Response$SomeObject extends JsonSerializable
+    with EquatableMixin {
   SomeQuery$Response$SomeObject();
 
   factory SomeQuery$Response$SomeObject.fromJson(Map<String, dynamic> json) =>
@@ -125,7 +126,7 @@ class SomeQuery$Response$SomeObject with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$Response with EquatableMixin {
+class SomeQuery$Response extends JsonSerializable with EquatableMixin {
   SomeQuery$Response();
 
   factory SomeQuery$Response.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/aliases/alias_on_object_test.dart
+++ b/test/query_generator/aliases/alias_on_object_test.dart
@@ -112,7 +112,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$QueryResponse$SomeObject with EquatableMixin {
+class SomeQuery$QueryResponse$SomeObject extends JsonSerializable
+    with EquatableMixin {
   SomeQuery$QueryResponse$SomeObject();
 
   factory SomeQuery$QueryResponse$SomeObject.fromJson(
@@ -128,7 +129,8 @@ class SomeQuery$QueryResponse$SomeObject with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$QueryResponse$AnotherObject with EquatableMixin {
+class SomeQuery$QueryResponse$AnotherObject extends JsonSerializable
+    with EquatableMixin {
   SomeQuery$QueryResponse$AnotherObject();
 
   factory SomeQuery$QueryResponse$AnotherObject.fromJson(
@@ -144,7 +146,7 @@ class SomeQuery$QueryResponse$AnotherObject with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$QueryResponse with EquatableMixin {
+class SomeQuery$QueryResponse extends JsonSerializable with EquatableMixin {
   SomeQuery$QueryResponse();
 
   factory SomeQuery$QueryResponse.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/append_type_name_test.dart
+++ b/test/query_generator/append_type_name_test.dart
@@ -90,7 +90,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot$Q with EquatableMixin {
+class Custom$QueryRoot$Q extends JsonSerializable with EquatableMixin {
   Custom$QueryRoot$Q();
 
   factory Custom$QueryRoot$Q.fromJson(Map<String, dynamic> json) =>
@@ -107,7 +107,7 @@ class Custom$QueryRoot$Q with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot with EquatableMixin {
+class Custom$QueryRoot extends JsonSerializable with EquatableMixin {
   Custom$QueryRoot();
 
   factory Custom$QueryRoot.fromJson(Map<String, dynamic> json) =>
@@ -206,7 +206,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot$Q with EquatableMixin {
+class Custom$QueryRoot$Q extends JsonSerializable with EquatableMixin {
   Custom$QueryRoot$Q();
 
   factory Custom$QueryRoot$Q.fromJson(Map<String, dynamic> json) =>
@@ -223,7 +223,7 @@ class Custom$QueryRoot$Q with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot with EquatableMixin {
+class Custom$QueryRoot extends JsonSerializable with EquatableMixin {
   Custom$QueryRoot();
 
   factory Custom$QueryRoot.fromJson(Map<String, dynamic> json) =>
@@ -341,7 +341,8 @@ mixin QueryResponseMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot$Q with EquatableMixin, QueryResponseMixin {
+class Custom$QueryRoot$Q extends JsonSerializable
+    with EquatableMixin, QueryResponseMixin {
   Custom$QueryRoot$Q();
 
   factory Custom$QueryRoot$Q.fromJson(Map<String, dynamic> json) =>
@@ -356,7 +357,7 @@ class Custom$QueryRoot$Q with EquatableMixin, QueryResponseMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot with EquatableMixin {
+class Custom$QueryRoot extends JsonSerializable with EquatableMixin {
   Custom$QueryRoot();
 
   factory Custom$QueryRoot.fromJson(Map<String, dynamic> json) =>
@@ -538,7 +539,7 @@ class Custom$QueryRoot$Q$TypeB extends Custom$QueryRoot$Q with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot$Q with EquatableMixin {
+class Custom$QueryRoot$Q extends JsonSerializable with EquatableMixin {
   Custom$QueryRoot$Q();
 
   factory Custom$QueryRoot$Q.fromJson(Map<String, dynamic> json) {
@@ -570,7 +571,7 @@ class Custom$QueryRoot$Q with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot with EquatableMixin {
+class Custom$QueryRoot extends JsonSerializable with EquatableMixin {
   Custom$QueryRoot();
 
   factory Custom$QueryRoot.fromJson(Map<String, dynamic> json) =>
@@ -685,7 +686,8 @@ mixin QueryResponseMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot$QueryResponse with EquatableMixin, QueryResponseMixin {
+class Custom$QueryRoot$QueryResponse extends JsonSerializable
+    with EquatableMixin, QueryResponseMixin {
   Custom$QueryRoot$QueryResponse();
 
   factory Custom$QueryRoot$QueryResponse.fromJson(Map<String, dynamic> json) =>
@@ -700,7 +702,7 @@ class Custom$QueryRoot$QueryResponse with EquatableMixin, QueryResponseMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot with EquatableMixin {
+class Custom$QueryRoot extends JsonSerializable with EquatableMixin {
   Custom$QueryRoot();
 
   factory Custom$QueryRoot.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/ast_schema/field_not_found_mutation_test.dart
+++ b/test/query_generator/ast_schema/field_not_found_mutation_test.dart
@@ -141,7 +141,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class CreateThing$MutationRoot$CreateThingResponse$Thing with EquatableMixin {
+class CreateThing$MutationRoot$CreateThingResponse$Thing
+    extends JsonSerializable with EquatableMixin {
   CreateThing$MutationRoot$CreateThingResponse$Thing();
 
   factory CreateThing$MutationRoot$CreateThingResponse$Thing.fromJson(
@@ -159,7 +160,8 @@ class CreateThing$MutationRoot$CreateThingResponse$Thing with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class CreateThing$MutationRoot$CreateThingResponse with EquatableMixin {
+class CreateThing$MutationRoot$CreateThingResponse extends JsonSerializable
+    with EquatableMixin {
   CreateThing$MutationRoot$CreateThingResponse();
 
   factory CreateThing$MutationRoot$CreateThingResponse.fromJson(
@@ -175,7 +177,7 @@ class CreateThing$MutationRoot$CreateThingResponse with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class CreateThing$MutationRoot with EquatableMixin {
+class CreateThing$MutationRoot extends JsonSerializable with EquatableMixin {
   CreateThing$MutationRoot();
 
   factory CreateThing$MutationRoot.fromJson(Map<String, dynamic> json) =>
@@ -189,7 +191,7 @@ class CreateThing$MutationRoot with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class CreateThingInput with EquatableMixin {
+class CreateThingInput extends JsonSerializable with EquatableMixin {
   CreateThingInput({@required this.clientId, this.message});
 
   factory CreateThingInput.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/ast_schema/input_types_test.dart
+++ b/test/query_generator/ast_schema/input_types_test.dart
@@ -163,7 +163,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class CreateThing$MutationRoot$CreateThingResponse$Thing with EquatableMixin {
+class CreateThing$MutationRoot$CreateThingResponse$Thing
+    extends JsonSerializable with EquatableMixin {
   CreateThing$MutationRoot$CreateThingResponse$Thing();
 
   factory CreateThing$MutationRoot$CreateThingResponse$Thing.fromJson(
@@ -181,7 +182,8 @@ class CreateThing$MutationRoot$CreateThingResponse$Thing with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class CreateThing$MutationRoot$CreateThingResponse with EquatableMixin {
+class CreateThing$MutationRoot$CreateThingResponse extends JsonSerializable
+    with EquatableMixin {
   CreateThing$MutationRoot$CreateThingResponse();
 
   factory CreateThing$MutationRoot$CreateThingResponse.fromJson(
@@ -197,7 +199,7 @@ class CreateThing$MutationRoot$CreateThingResponse with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class CreateThing$MutationRoot with EquatableMixin {
+class CreateThing$MutationRoot extends JsonSerializable with EquatableMixin {
   CreateThing$MutationRoot();
 
   factory CreateThing$MutationRoot.fromJson(Map<String, dynamic> json) =>
@@ -211,7 +213,7 @@ class CreateThing$MutationRoot with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class OtherObjectInput with EquatableMixin {
+class OtherObjectInput extends JsonSerializable with EquatableMixin {
   OtherObjectInput({@required this.id});
 
   factory OtherObjectInput.fromJson(Map<String, dynamic> json) =>
@@ -225,7 +227,7 @@ class OtherObjectInput with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class CreateThingInput with EquatableMixin {
+class CreateThingInput extends JsonSerializable with EquatableMixin {
   CreateThingInput({@required this.clientId, this.message, this.shares});
 
   factory CreateThingInput.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/ast_schema/missing_schema_test.dart
+++ b/test/query_generator/ast_schema/missing_schema_test.dart
@@ -60,7 +60,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Query$Query with EquatableMixin {
+class Query$Query extends JsonSerializable with EquatableMixin {
   Query$Query();
 
   factory Query$Query.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/ast_schema/multiple_schema_mappint_test.dart
+++ b/test/query_generator/ast_schema/multiple_schema_mappint_test.dart
@@ -309,7 +309,8 @@ import 'package:gql/ast.dart';
 part 'outputA.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class BrowseArticles$Query$Articles with EquatableMixin {
+class BrowseArticles$Query$Articles extends JsonSerializable
+    with EquatableMixin {
   BrowseArticles$Query$Articles();
 
   factory BrowseArticles$Query$Articles.fromJson(Map<String, dynamic> json) =>
@@ -328,7 +329,7 @@ class BrowseArticles$Query$Articles with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class BrowseArticles$Query with EquatableMixin {
+class BrowseArticles$Query extends JsonSerializable with EquatableMixin {
   BrowseArticles$Query();
 
   factory BrowseArticles$Query.fromJson(Map<String, dynamic> json) =>
@@ -410,7 +411,8 @@ import 'package:gql/ast.dart';
 part 'outputB.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class BrowseRepositories$Query$Repositories with EquatableMixin {
+class BrowseRepositories$Query$Repositories extends JsonSerializable
+    with EquatableMixin {
   BrowseRepositories$Query$Repositories();
 
   factory BrowseRepositories$Query$Repositories.fromJson(
@@ -434,7 +436,7 @@ class BrowseRepositories$Query$Repositories with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class BrowseRepositories$Query with EquatableMixin {
+class BrowseRepositories$Query extends JsonSerializable with EquatableMixin {
   BrowseRepositories$Query();
 
   factory BrowseRepositories$Query.fromJson(Map<String, dynamic> json) =>
@@ -448,7 +450,7 @@ class BrowseRepositories$Query with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class NotificationOptionInput with EquatableMixin {
+class NotificationOptionInput extends JsonSerializable with EquatableMixin {
   NotificationOptionInput({this.type, this.enabled});
 
   factory NotificationOptionInput.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/deprecated/deprecated_enum_value_test.dart
+++ b/test/query_generator/deprecated/deprecated_enum_value_test.dart
@@ -96,7 +96,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$QueryResponse with EquatableMixin {
+class SomeQuery$QueryResponse extends JsonSerializable with EquatableMixin {
   SomeQuery$QueryResponse();
 
   factory SomeQuery$QueryResponse.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/deprecated/deprecated_field_test.dart
+++ b/test/query_generator/deprecated/deprecated_field_test.dart
@@ -125,7 +125,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$QueryResponse$DeprecatedObject with EquatableMixin {
+class SomeQuery$QueryResponse$DeprecatedObject extends JsonSerializable
+    with EquatableMixin {
   SomeQuery$QueryResponse$DeprecatedObject();
 
   factory SomeQuery$QueryResponse$DeprecatedObject.fromJson(
@@ -144,7 +145,8 @@ class SomeQuery$QueryResponse$DeprecatedObject with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$QueryResponse$SomeObject with EquatableMixin {
+class SomeQuery$QueryResponse$SomeObject extends JsonSerializable
+    with EquatableMixin {
   SomeQuery$QueryResponse$SomeObject();
 
   factory SomeQuery$QueryResponse$SomeObject.fromJson(
@@ -163,7 +165,7 @@ class SomeQuery$QueryResponse$SomeObject with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$QueryResponse with EquatableMixin {
+class SomeQuery$QueryResponse extends JsonSerializable with EquatableMixin {
   SomeQuery$QueryResponse();
 
   factory SomeQuery$QueryResponse.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/deprecated/deprecated_input_object_field_test.dart
+++ b/test/query_generator/deprecated/deprecated_input_object_field_test.dart
@@ -123,7 +123,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Custom$MutationRoot$MutationResponse with EquatableMixin {
+class Custom$MutationRoot$MutationResponse extends JsonSerializable
+    with EquatableMixin {
   Custom$MutationRoot$MutationResponse();
 
   factory Custom$MutationRoot$MutationResponse.fromJson(
@@ -139,7 +140,7 @@ class Custom$MutationRoot$MutationResponse with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$MutationRoot with EquatableMixin {
+class Custom$MutationRoot extends JsonSerializable with EquatableMixin {
   Custom$MutationRoot();
 
   factory Custom$MutationRoot.fromJson(Map<String, dynamic> json) =>
@@ -153,7 +154,7 @@ class Custom$MutationRoot with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Input with EquatableMixin {
+class Input extends JsonSerializable with EquatableMixin {
   Input({@required this.s, this.d});
 
   factory Input.fromJson(Map<String, dynamic> json) => _$InputFromJson(json);

--- a/test/query_generator/deprecated/deprecated_interface_field_test.dart
+++ b/test/query_generator/deprecated/deprecated_interface_field_test.dart
@@ -249,7 +249,7 @@ class Custom$Query$Node$ChatMessage extends Custom$Query$Node
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Query$Node with EquatableMixin {
+class Custom$Query$Node extends JsonSerializable with EquatableMixin {
   Custom$Query$Node();
 
   factory Custom$Query$Node.fromJson(Map<String, dynamic> json) {
@@ -283,7 +283,7 @@ class Custom$Query$Node with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Query with EquatableMixin {
+class Custom$Query extends JsonSerializable with EquatableMixin {
   Custom$Query();
 
   factory Custom$Query.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/enums/enum_duplication_test.dart
+++ b/test/query_generator/enums/enum_duplication_test.dart
@@ -162,7 +162,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Query$Q with EquatableMixin {
+class Custom$Query$Q extends JsonSerializable with EquatableMixin {
   Custom$Query$Q();
 
   factory Custom$Query$Q.fromJson(Map<String, dynamic> json) =>
@@ -177,7 +177,7 @@ class Custom$Query$Q with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Query with EquatableMixin {
+class Custom$Query extends JsonSerializable with EquatableMixin {
   Custom$Query();
 
   factory Custom$Query.fromJson(Map<String, dynamic> json) =>
@@ -191,7 +191,7 @@ class Custom$Query with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class CustomList$Query$QList with EquatableMixin {
+class CustomList$Query$QList extends JsonSerializable with EquatableMixin {
   CustomList$Query$QList();
 
   factory CustomList$Query$QList.fromJson(Map<String, dynamic> json) =>
@@ -206,7 +206,7 @@ class CustomList$Query$QList with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class CustomList$Query with EquatableMixin {
+class CustomList$Query extends JsonSerializable with EquatableMixin {
   CustomList$Query();
 
   factory CustomList$Query.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/enums/enum_list_test.dart
+++ b/test/query_generator/enums/enum_list_test.dart
@@ -102,7 +102,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot$QueryResponse with EquatableMixin {
+class Custom$QueryRoot$QueryResponse extends JsonSerializable
+    with EquatableMixin {
   Custom$QueryRoot$QueryResponse();
 
   factory Custom$QueryRoot$QueryResponse.fromJson(Map<String, dynamic> json) =>
@@ -117,7 +118,7 @@ class Custom$QueryRoot$QueryResponse with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot with EquatableMixin {
+class Custom$QueryRoot extends JsonSerializable with EquatableMixin {
   Custom$QueryRoot();
 
   factory Custom$QueryRoot.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/enums/filter_enum_test.dart
+++ b/test/query_generator/enums/filter_enum_test.dart
@@ -166,7 +166,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot$QueryResponse with EquatableMixin {
+class Custom$QueryRoot$QueryResponse extends JsonSerializable
+    with EquatableMixin {
   Custom$QueryRoot$QueryResponse();
 
   factory Custom$QueryRoot$QueryResponse.fromJson(Map<String, dynamic> json) =>
@@ -181,7 +182,7 @@ class Custom$QueryRoot$QueryResponse with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot with EquatableMixin {
+class Custom$QueryRoot extends JsonSerializable with EquatableMixin {
   Custom$QueryRoot();
 
   factory Custom$QueryRoot.fromJson(Map<String, dynamic> json) =>
@@ -195,7 +196,7 @@ class Custom$QueryRoot with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Input with EquatableMixin {
+class Input extends JsonSerializable with EquatableMixin {
   Input({this.e});
 
   factory Input.fromJson(Map<String, dynamic> json) => _$InputFromJson(json);

--- a/test/query_generator/enums/input_enum_list_test.dart
+++ b/test/query_generator/enums/input_enum_list_test.dart
@@ -121,7 +121,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class BrowseArticles$Query$Article with EquatableMixin {
+class BrowseArticles$Query$Article extends JsonSerializable
+    with EquatableMixin {
   BrowseArticles$Query$Article();
 
   factory BrowseArticles$Query$Article.fromJson(Map<String, dynamic> json) =>
@@ -140,7 +141,7 @@ class BrowseArticles$Query$Article with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class BrowseArticles$Query with EquatableMixin {
+class BrowseArticles$Query extends JsonSerializable with EquatableMixin {
   BrowseArticles$Query();
 
   factory BrowseArticles$Query.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/enums/input_enum_test.dart
+++ b/test/query_generator/enums/input_enum_test.dart
@@ -163,7 +163,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot$QueryResponse with EquatableMixin {
+class Custom$QueryRoot$QueryResponse extends JsonSerializable
+    with EquatableMixin {
   Custom$QueryRoot$QueryResponse();
 
   factory Custom$QueryRoot$QueryResponse.fromJson(Map<String, dynamic> json) =>
@@ -183,7 +184,7 @@ class Custom$QueryRoot$QueryResponse with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot with EquatableMixin {
+class Custom$QueryRoot extends JsonSerializable with EquatableMixin {
   Custom$QueryRoot();
 
   factory Custom$QueryRoot.fromJson(Map<String, dynamic> json) =>
@@ -197,7 +198,7 @@ class Custom$QueryRoot with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Input with EquatableMixin {
+class Input extends JsonSerializable with EquatableMixin {
   Input({@required this.e});
 
   factory Input.fromJson(Map<String, dynamic> json) => _$InputFromJson(json);

--- a/test/query_generator/enums/kw_prefix_test.dart
+++ b/test/query_generator/enums/kw_prefix_test.dart
@@ -127,7 +127,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SearchArticles$Query$Article with EquatableMixin {
+class SearchArticles$Query$Article extends JsonSerializable
+    with EquatableMixin {
   SearchArticles$Query$Article();
 
   factory SearchArticles$Query$Article.fromJson(Map<String, dynamic> json) =>
@@ -143,7 +144,7 @@ class SearchArticles$Query$Article with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SearchArticles$Query with EquatableMixin {
+class SearchArticles$Query extends JsonSerializable with EquatableMixin {
   SearchArticles$Query();
 
   factory SearchArticles$Query.fromJson(Map<String, dynamic> json) =>
@@ -157,7 +158,7 @@ class SearchArticles$Query with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class ArticleTitleWhereConditions with EquatableMixin {
+class ArticleTitleWhereConditions extends JsonSerializable with EquatableMixin {
   ArticleTitleWhereConditions({this.kw$operator, this.value});
 
   factory ArticleTitleWhereConditions.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/enums/query_enum_test.dart
+++ b/test/query_generator/enums/query_enum_test.dart
@@ -98,7 +98,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot$QueryResponse with EquatableMixin {
+class Custom$QueryRoot$QueryResponse extends JsonSerializable
+    with EquatableMixin {
   Custom$QueryRoot$QueryResponse();
 
   factory Custom$QueryRoot$QueryResponse.fromJson(Map<String, dynamic> json) =>
@@ -113,7 +114,7 @@ class Custom$QueryRoot$QueryResponse with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot with EquatableMixin {
+class Custom$QueryRoot extends JsonSerializable with EquatableMixin {
   Custom$QueryRoot();
 
   factory Custom$QueryRoot.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/forwarder_test.dart
+++ b/test/query_generator/forwarder_test.dart
@@ -78,7 +78,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Custom$QueryRoot with EquatableMixin {
+class Custom$QueryRoot extends JsonSerializable with EquatableMixin {
   Custom$QueryRoot();
 
   factory Custom$QueryRoot.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/fragments/fragment_duplication_test.dart
+++ b/test/query_generator/fragments/fragment_duplication_test.dart
@@ -243,7 +243,7 @@ mixin PokemonPartsMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class PokemonData$Query$Pokemon
+class PokemonData$Query$Pokemon extends JsonSerializable
     with EquatableMixin, PokemonMixin, PokemonPartsMixin {
   PokemonData$Query$Pokemon();
 
@@ -256,7 +256,7 @@ class PokemonData$Query$Pokemon
 }
 
 @JsonSerializable(explicitToJson: true)
-class PokemonData$Query with EquatableMixin {
+class PokemonData$Query extends JsonSerializable with EquatableMixin {
   PokemonData$Query();
 
   factory PokemonData$Query.fromJson(Map<String, dynamic> json) =>
@@ -270,7 +270,8 @@ class PokemonData$Query with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class PokemonMixin$Evolution with EquatableMixin, PokemonNameMixin {
+class PokemonMixin$Evolution extends JsonSerializable
+    with EquatableMixin, PokemonNameMixin {
   PokemonMixin$Evolution();
 
   factory PokemonMixin$Evolution.fromJson(Map<String, dynamic> json) =>
@@ -282,7 +283,7 @@ class PokemonMixin$Evolution with EquatableMixin, PokemonNameMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class AllPokemonsData$Query$AllPokemons
+class AllPokemonsData$Query$AllPokemons extends JsonSerializable
     with EquatableMixin, PokemonMixin, PokemonPartsMixin {
   AllPokemonsData$Query$AllPokemons();
 
@@ -297,7 +298,7 @@ class AllPokemonsData$Query$AllPokemons
 }
 
 @JsonSerializable(explicitToJson: true)
-class AllPokemonsData$Query with EquatableMixin {
+class AllPokemonsData$Query extends JsonSerializable with EquatableMixin {
   AllPokemonsData$Query();
 
   factory AllPokemonsData$Query.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/fragments/fragment_glob_test.dart
+++ b/test/query_generator/fragments/fragment_glob_test.dart
@@ -216,7 +216,8 @@ mixin AttackMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Query$Query$Pokemon$Pokemon with EquatableMixin, PokemonMixin {
+class Query$Query$Pokemon$Pokemon extends JsonSerializable
+    with EquatableMixin, PokemonMixin {
   Query$Query$Pokemon$Pokemon();
 
   factory Query$Query$Pokemon$Pokemon.fromJson(Map<String, dynamic> json) =>
@@ -228,7 +229,8 @@ class Query$Query$Pokemon$Pokemon with EquatableMixin, PokemonMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Query$Query$Pokemon with EquatableMixin, PokemonMixin {
+class Query$Query$Pokemon extends JsonSerializable
+    with EquatableMixin, PokemonMixin {
   Query$Query$Pokemon();
 
   factory Query$Query$Pokemon.fromJson(Map<String, dynamic> json) =>
@@ -242,7 +244,7 @@ class Query$Query$Pokemon with EquatableMixin, PokemonMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Query$Query with EquatableMixin {
+class Query$Query extends JsonSerializable with EquatableMixin {
   Query$Query();
 
   factory Query$Query.fromJson(Map<String, dynamic> json) =>
@@ -256,7 +258,8 @@ class Query$Query with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class PokemonMixin$PokemonDimension with EquatableMixin, WeightMixin {
+class PokemonMixin$PokemonDimension extends JsonSerializable
+    with EquatableMixin, WeightMixin {
   PokemonMixin$PokemonDimension();
 
   factory PokemonMixin$PokemonDimension.fromJson(Map<String, dynamic> json) =>
@@ -268,7 +271,8 @@ class PokemonMixin$PokemonDimension with EquatableMixin, WeightMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class PokemonMixin$PokemonAttack with EquatableMixin, PokemonAttackMixin {
+class PokemonMixin$PokemonAttack extends JsonSerializable
+    with EquatableMixin, PokemonAttackMixin {
   PokemonMixin$PokemonAttack();
 
   factory PokemonMixin$PokemonAttack.fromJson(Map<String, dynamic> json) =>
@@ -280,7 +284,8 @@ class PokemonMixin$PokemonAttack with EquatableMixin, PokemonAttackMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class PokemonAttackMixin$Attack with EquatableMixin, AttackMixin {
+class PokemonAttackMixin$Attack extends JsonSerializable
+    with EquatableMixin, AttackMixin {
   PokemonAttackMixin$Attack();
 
   factory PokemonAttackMixin$Attack.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/fragments/fragment_on_fragments_test.dart
+++ b/test/query_generator/fragments/fragment_on_fragments_test.dart
@@ -158,7 +158,8 @@ mixin PokemonPartsMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Query$Query$Pokemon with EquatableMixin, PokemonMixin, PokemonPartsMixin {
+class Query$Query$Pokemon extends JsonSerializable
+    with EquatableMixin, PokemonMixin, PokemonPartsMixin {
   Query$Query$Pokemon();
 
   factory Query$Query$Pokemon.fromJson(Map<String, dynamic> json) =>
@@ -170,7 +171,7 @@ class Query$Query$Pokemon with EquatableMixin, PokemonMixin, PokemonPartsMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Query$Query with EquatableMixin {
+class Query$Query extends JsonSerializable with EquatableMixin {
   Query$Query();
 
   factory Query$Query.fromJson(Map<String, dynamic> json) =>
@@ -184,7 +185,8 @@ class Query$Query with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class PokemonMixin$Pokemon with EquatableMixin, PokemonNameMixin {
+class PokemonMixin$Pokemon extends JsonSerializable
+    with EquatableMixin, PokemonNameMixin {
   PokemonMixin$Pokemon();
 
   factory PokemonMixin$Pokemon.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/fragments/fragments_multiple_test.dart
+++ b/test/query_generator/fragments/fragments_multiple_test.dart
@@ -239,7 +239,8 @@ mixin DepartureMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class VoyagesData$Query$VoyageList$VoyageDetails$Voyage with EquatableMixin {
+class VoyagesData$Query$VoyageList$VoyageDetails$Voyage extends JsonSerializable
+    with EquatableMixin {
   VoyagesData$Query$VoyageList$VoyageDetails$Voyage();
 
   factory VoyagesData$Query$VoyageList$VoyageDetails$Voyage.fromJson(
@@ -261,7 +262,8 @@ class VoyagesData$Query$VoyageList$VoyageDetails$Voyage with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class VoyagesData$Query$VoyageList$VoyageDetails with EquatableMixin {
+class VoyagesData$Query$VoyageList$VoyageDetails extends JsonSerializable
+    with EquatableMixin {
   VoyagesData$Query$VoyageList$VoyageDetails();
 
   factory VoyagesData$Query$VoyageList$VoyageDetails.fromJson(
@@ -279,7 +281,8 @@ class VoyagesData$Query$VoyageList$VoyageDetails with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class VoyagesData$Query$VoyageList with EquatableMixin {
+class VoyagesData$Query$VoyageList extends JsonSerializable
+    with EquatableMixin {
   VoyagesData$Query$VoyageList();
 
   factory VoyagesData$Query$VoyageList.fromJson(Map<String, dynamic> json) =>
@@ -293,7 +296,7 @@ class VoyagesData$Query$VoyageList with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class VoyagesData$Query with EquatableMixin {
+class VoyagesData$Query extends JsonSerializable with EquatableMixin {
   VoyagesData$Query();
 
   factory VoyagesData$Query.fromJson(Map<String, dynamic> json) =>
@@ -307,7 +310,7 @@ class VoyagesData$Query with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class PaginationInput with EquatableMixin {
+class PaginationInput extends JsonSerializable with EquatableMixin {
   PaginationInput({@required this.limit, @required this.offset});
 
   factory PaginationInput.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/fragments/fragments_test.dart
+++ b/test/query_generator/fragments/fragments_test.dart
@@ -80,7 +80,8 @@ mixin MyFragmentMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$SomeObject with EquatableMixin, MyFragmentMixin {
+class SomeQuery$SomeObject extends JsonSerializable
+    with EquatableMixin, MyFragmentMixin {
   SomeQuery$SomeObject();
 
   factory SomeQuery$SomeObject.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/fragments/multiple_references_on_simple_naming_test.dart
+++ b/test/query_generator/fragments/multiple_references_on_simple_naming_test.dart
@@ -137,7 +137,7 @@ mixin MyFragmentMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeObject with EquatableMixin, MyFragmentMixin {
+class SomeObject extends JsonSerializable with EquatableMixin, MyFragmentMixin {
   SomeObject();
 
   factory SomeObject.fromJson(Map<String, dynamic> json) =>
@@ -149,7 +149,7 @@ class SomeObject with EquatableMixin, MyFragmentMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class MoreData with EquatableMixin {
+class MoreData extends JsonSerializable with EquatableMixin {
   MoreData();
 
   factory MoreData.fromJson(Map<String, dynamic> json) =>
@@ -163,7 +163,7 @@ class MoreData with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$QueryResponse with EquatableMixin {
+class SomeQuery$QueryResponse extends JsonSerializable with EquatableMixin {
   SomeQuery$QueryResponse();
 
   factory SomeQuery$QueryResponse.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/interfaces/interface_fragment_glob_test.dart
+++ b/test/query_generator/interfaces/interface_fragment_glob_test.dart
@@ -240,7 +240,7 @@ class Custom$Query$NodeById$ChatMessage extends Custom$Query$NodeById
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Query$NodeById with EquatableMixin {
+class Custom$Query$NodeById extends JsonSerializable with EquatableMixin {
   Custom$Query$NodeById();
 
   factory Custom$Query$NodeById.fromJson(Map<String, dynamic> json) {
@@ -274,7 +274,7 @@ class Custom$Query$NodeById with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Query with EquatableMixin {
+class Custom$Query extends JsonSerializable with EquatableMixin {
   Custom$Query();
 
   factory Custom$Query.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/interfaces/interface_possible_types_test.dart
+++ b/test/query_generator/interfaces/interface_possible_types_test.dart
@@ -183,7 +183,7 @@ class Custom$Query$Node$ChatMessage extends Custom$Query$Node
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Query$Node with EquatableMixin {
+class Custom$Query$Node extends JsonSerializable with EquatableMixin {
   Custom$Query$Node();
 
   factory Custom$Query$Node.fromJson(Map<String, dynamic> json) {
@@ -217,7 +217,7 @@ class Custom$Query$Node with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Query with EquatableMixin {
+class Custom$Query extends JsonSerializable with EquatableMixin {
   Custom$Query();
 
   factory Custom$Query.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/interfaces/interface_test.dart
+++ b/test/query_generator/interfaces/interface_test.dart
@@ -228,7 +228,7 @@ class Custom$Query$Node$ChatMessage extends Custom$Query$Node
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Query$Node with EquatableMixin {
+class Custom$Query$Node extends JsonSerializable with EquatableMixin {
   Custom$Query$Node();
 
   factory Custom$Query$Node.fromJson(Map<String, dynamic> json) {
@@ -262,7 +262,7 @@ class Custom$Query$Node with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Query with EquatableMixin {
+class Custom$Query extends JsonSerializable with EquatableMixin {
   Custom$Query();
 
   factory Custom$Query.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/multiple_operations_per_file_test.dart
+++ b/test/query_generator/multiple_operations_per_file_test.dart
@@ -177,7 +177,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class MutData$Mutation$MutationResponse with EquatableMixin {
+class MutData$Mutation$MutationResponse extends JsonSerializable
+    with EquatableMixin {
   MutData$Mutation$MutationResponse();
 
   factory MutData$Mutation$MutationResponse.fromJson(
@@ -193,7 +194,7 @@ class MutData$Mutation$MutationResponse with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class MutData$Mutation with EquatableMixin {
+class MutData$Mutation extends JsonSerializable with EquatableMixin {
   MutData$Mutation();
 
   factory MutData$Mutation.fromJson(Map<String, dynamic> json) =>
@@ -207,7 +208,7 @@ class MutData$Mutation with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Input with EquatableMixin {
+class Input extends JsonSerializable with EquatableMixin {
   Input({@required this.s});
 
   factory Input.fromJson(Map<String, dynamic> json) => _$InputFromJson(json);
@@ -220,7 +221,7 @@ class Input with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class QueData$Query$QueryResponse with EquatableMixin {
+class QueData$Query$QueryResponse extends JsonSerializable with EquatableMixin {
   QueData$Query$QueryResponse();
 
   factory QueData$Query$QueryResponse.fromJson(Map<String, dynamic> json) =>
@@ -238,7 +239,7 @@ class QueData$Query$QueryResponse with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class QueData$Query with EquatableMixin {
+class QueData$Query extends JsonSerializable with EquatableMixin {
   QueData$Query();
 
   factory QueData$Query.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/multiple_queries_test.dart
+++ b/test/query_generator/multiple_queries_test.dart
@@ -86,7 +86,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$SomeObject with EquatableMixin {
+class SomeQuery$SomeObject extends JsonSerializable with EquatableMixin {
   SomeQuery$SomeObject();
 
   factory SomeQuery$SomeObject.fromJson(Map<String, dynamic> json) =>
@@ -102,7 +102,7 @@ class SomeQuery$SomeObject with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class AnotherQuery$SomeObject with EquatableMixin {
+class AnotherQuery$SomeObject extends JsonSerializable with EquatableMixin {
   AnotherQuery$SomeObject();
 
   factory AnotherQuery$SomeObject.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/mutations_and_inputs/complex_input_objects_test.dart
+++ b/test/query_generator/mutations_and_inputs/complex_input_objects_test.dart
@@ -142,7 +142,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$QueryRoot$SomeObject with EquatableMixin {
+class SomeQuery$QueryRoot$SomeObject extends JsonSerializable
+    with EquatableMixin {
   SomeQuery$QueryRoot$SomeObject();
 
   factory SomeQuery$QueryRoot$SomeObject.fromJson(Map<String, dynamic> json) =>
@@ -156,7 +157,7 @@ class SomeQuery$QueryRoot$SomeObject with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$QueryRoot with EquatableMixin {
+class SomeQuery$QueryRoot extends JsonSerializable with EquatableMixin {
   SomeQuery$QueryRoot();
 
   factory SomeQuery$QueryRoot.fromJson(Map<String, dynamic> json) =>
@@ -170,7 +171,7 @@ class SomeQuery$QueryRoot with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class ComplexInput with EquatableMixin {
+class ComplexInput extends JsonSerializable with EquatableMixin {
   ComplexInput({@required this.s, this.e, this.ls, this.i});
 
   factory ComplexInput.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/mutations_and_inputs/custom_scalars_on_input_objects_test.dart
+++ b/test/query_generator/mutations_and_inputs/custom_scalars_on_input_objects_test.dart
@@ -144,7 +144,8 @@ import 'package:example/src/custom_parser.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Custom$MutationRoot$MutationResponse with EquatableMixin {
+class Custom$MutationRoot$MutationResponse extends JsonSerializable
+    with EquatableMixin {
   Custom$MutationRoot$MutationResponse();
 
   factory Custom$MutationRoot$MutationResponse.fromJson(
@@ -160,7 +161,7 @@ class Custom$MutationRoot$MutationResponse with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$MutationRoot with EquatableMixin {
+class Custom$MutationRoot extends JsonSerializable with EquatableMixin {
   Custom$MutationRoot();
 
   factory Custom$MutationRoot.fromJson(Map<String, dynamic> json) =>
@@ -174,7 +175,7 @@ class Custom$MutationRoot with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Input with EquatableMixin {
+class Input extends JsonSerializable with EquatableMixin {
   Input({@required this.id});
 
   factory Input.fromJson(Map<String, dynamic> json) => _$InputFromJson(json);

--- a/test/query_generator/mutations_and_inputs/filter_input_objects_test.dart
+++ b/test/query_generator/mutations_and_inputs/filter_input_objects_test.dart
@@ -129,7 +129,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$QueryRoot$SomeObject with EquatableMixin {
+class SomeQuery$QueryRoot$SomeObject extends JsonSerializable
+    with EquatableMixin {
   SomeQuery$QueryRoot$SomeObject();
 
   factory SomeQuery$QueryRoot$SomeObject.fromJson(Map<String, dynamic> json) =>
@@ -143,7 +144,7 @@ class SomeQuery$QueryRoot$SomeObject with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$QueryRoot with EquatableMixin {
+class SomeQuery$QueryRoot extends JsonSerializable with EquatableMixin {
   SomeQuery$QueryRoot();
 
   factory SomeQuery$QueryRoot.fromJson(Map<String, dynamic> json) =>
@@ -157,7 +158,7 @@ class SomeQuery$QueryRoot with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Input with EquatableMixin {
+class Input extends JsonSerializable with EquatableMixin {
   Input({this.s});
 
   factory Input.fromJson(Map<String, dynamic> json) => _$InputFromJson(json);
@@ -170,7 +171,7 @@ class Input with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SubInput with EquatableMixin {
+class SubInput extends JsonSerializable with EquatableMixin {
   SubInput({this.s});
 
   factory SubInput.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/mutations_and_inputs/input_duplication_test.dart
+++ b/test/query_generator/mutations_and_inputs/input_duplication_test.dart
@@ -169,7 +169,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Mutation$Mut with EquatableMixin {
+class Custom$Mutation$Mut extends JsonSerializable with EquatableMixin {
   Custom$Mutation$Mut();
 
   factory Custom$Mutation$Mut.fromJson(Map<String, dynamic> json) =>
@@ -183,7 +183,7 @@ class Custom$Mutation$Mut with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Mutation with EquatableMixin {
+class Custom$Mutation extends JsonSerializable with EquatableMixin {
   Custom$Mutation();
 
   factory Custom$Mutation.fromJson(Map<String, dynamic> json) =>
@@ -197,7 +197,7 @@ class Custom$Mutation with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Input with EquatableMixin {
+class Input extends JsonSerializable with EquatableMixin {
   Input({@required this.s});
 
   factory Input.fromJson(Map<String, dynamic> json) => _$InputFromJson(json);
@@ -210,7 +210,7 @@ class Input with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class CustomList$Mutation$MutList with EquatableMixin {
+class CustomList$Mutation$MutList extends JsonSerializable with EquatableMixin {
   CustomList$Mutation$MutList();
 
   factory CustomList$Mutation$MutList.fromJson(Map<String, dynamic> json) =>
@@ -224,7 +224,7 @@ class CustomList$Mutation$MutList with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class CustomList$Mutation with EquatableMixin {
+class CustomList$Mutation extends JsonSerializable with EquatableMixin {
   CustomList$Mutation();
 
   factory CustomList$Mutation.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/mutations_and_inputs/mutations_test.dart
+++ b/test/query_generator/mutations_and_inputs/mutations_test.dart
@@ -181,7 +181,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Custom$MutationRoot$MutationResponse with EquatableMixin {
+class Custom$MutationRoot$MutationResponse extends JsonSerializable
+    with EquatableMixin {
   Custom$MutationRoot$MutationResponse();
 
   factory Custom$MutationRoot$MutationResponse.fromJson(
@@ -197,7 +198,7 @@ class Custom$MutationRoot$MutationResponse with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Custom$MutationRoot with EquatableMixin {
+class Custom$MutationRoot extends JsonSerializable with EquatableMixin {
   Custom$MutationRoot();
 
   factory Custom$MutationRoot.fromJson(Map<String, dynamic> json) =>
@@ -211,7 +212,7 @@ class Custom$MutationRoot with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Input with EquatableMixin {
+class Input extends JsonSerializable with EquatableMixin {
   Input({@required this.s});
 
   factory Input.fromJson(Map<String, dynamic> json) => _$InputFromJson(json);
@@ -224,7 +225,8 @@ class Input with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class $custom$MutationRoot$$MutationResponse with EquatableMixin {
+class $custom$MutationRoot$$MutationResponse extends JsonSerializable
+    with EquatableMixin {
   $custom$MutationRoot$$MutationResponse();
 
   factory $custom$MutationRoot$$MutationResponse.fromJson(
@@ -241,7 +243,7 @@ class $custom$MutationRoot$$MutationResponse with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class $custom$MutationRoot with EquatableMixin {
+class $custom$MutationRoot extends JsonSerializable with EquatableMixin {
   $custom$MutationRoot();
 
   factory $custom$MutationRoot.fromJson(Map<String, dynamic> json) =>
@@ -256,7 +258,7 @@ class $custom$MutationRoot with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class $Input with EquatableMixin {
+class $Input extends JsonSerializable with EquatableMixin {
   $Input({@required this.$s});
 
   factory $Input.fromJson(Map<String, dynamic> json) => _$$InputFromJson(json);

--- a/test/query_generator/mutations_and_inputs/recursive_input_test.dart
+++ b/test/query_generator/mutations_and_inputs/recursive_input_test.dart
@@ -89,7 +89,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Custom$Mutation with EquatableMixin {
+class Custom$Mutation extends JsonSerializable with EquatableMixin {
   Custom$Mutation();
 
   factory Custom$Mutation.fromJson(Map<String, dynamic> json) =>
@@ -103,7 +103,7 @@ class Custom$Mutation with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Input with EquatableMixin {
+class Input extends JsonSerializable with EquatableMixin {
   Input({this.and, this.or});
 
   factory Input.fromJson(Map<String, dynamic> json) => _$InputFromJson(json);

--- a/test/query_generator/naming/casing_conversion_test.dart
+++ b/test/query_generator/naming/casing_conversion_test.dart
@@ -218,7 +218,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeObject with EquatableMixin {
+class SomeObject extends JsonSerializable with EquatableMixin {
   SomeObject();
 
   factory SomeObject.fromJson(Map<String, dynamic> json) =>
@@ -250,7 +250,7 @@ class SomeObject with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$Query with EquatableMixin {
+class SomeQuery$Query extends JsonSerializable with EquatableMixin {
   SomeQuery$Query();
 
   factory SomeQuery$Query.fromJson(Map<String, dynamic> json) =>
@@ -264,7 +264,7 @@ class SomeQuery$Query with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class Input with EquatableMixin {
+class Input extends JsonSerializable with EquatableMixin {
   Input(
       {this.camelCaseField,
       this.pascalCaseField,

--- a/test/query_generator/naming/simple_naming_test.dart
+++ b/test/query_generator/naming/simple_naming_test.dart
@@ -111,7 +111,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class ClientEventItem with EquatableMixin {
+class ClientEventItem extends JsonSerializable with EquatableMixin {
   ClientEventItem();
 
   factory ClientEventItem.fromJson(Map<String, dynamic> json) =>
@@ -125,7 +125,7 @@ class ClientEventItem with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class ClientEventPage with EquatableMixin {
+class ClientEventPage extends JsonSerializable with EquatableMixin {
   ClientEventPage();
 
   factory ClientEventPage.fromJson(Map<String, dynamic> json) =>
@@ -139,7 +139,7 @@ class ClientEventPage with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class ClientEventsData$Query with EquatableMixin {
+class ClientEventsData$Query extends JsonSerializable with EquatableMixin {
   ClientEventsData$Query();
 
   factory ClientEventsData$Query.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/query_generator_test.dart
+++ b/test/query_generator/query_generator_test.dart
@@ -71,7 +71,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$SomeObject with EquatableMixin {
+class SomeQuery$SomeObject extends JsonSerializable with EquatableMixin {
   SomeQuery$SomeObject();
 
   factory SomeQuery$SomeObject.fromJson(Map<String, dynamic> json) =>
@@ -180,7 +180,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$Query$SomeObject with EquatableMixin {
+class SomeQuery$Query$SomeObject extends JsonSerializable with EquatableMixin {
   SomeQuery$Query$SomeObject();
 
   factory SomeQuery$Query$SomeObject.fromJson(Map<String, dynamic> json) =>
@@ -198,7 +198,7 @@ class SomeQuery$Query$SomeObject with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$Query with EquatableMixin {
+class SomeQuery$Query extends JsonSerializable with EquatableMixin {
   SomeQuery$Query();
 
   factory SomeQuery$Query.fromJson(Map<String, dynamic> json) =>
@@ -414,7 +414,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$Result$SomeObject$AnotherObject with EquatableMixin {
+class SomeQuery$Result$SomeObject$AnotherObject extends JsonSerializable
+    with EquatableMixin {
   SomeQuery$Result$SomeObject$AnotherObject();
 
   factory SomeQuery$Result$SomeObject$AnotherObject.fromJson(
@@ -430,7 +431,7 @@ class SomeQuery$Result$SomeObject$AnotherObject with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$Result$SomeObject with EquatableMixin {
+class SomeQuery$Result$SomeObject extends JsonSerializable with EquatableMixin {
   SomeQuery$Result$SomeObject();
 
   factory SomeQuery$Result$SomeObject.fromJson(Map<String, dynamic> json) =>
@@ -446,7 +447,7 @@ class SomeQuery$Result$SomeObject with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$Result with EquatableMixin {
+class SomeQuery$Result extends JsonSerializable with EquatableMixin {
   SomeQuery$Result();
 
   factory SomeQuery$Result.fromJson(Map<String, dynamic> json) =>
@@ -512,7 +513,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$Result with EquatableMixin {
+class SomeQuery$Result extends JsonSerializable with EquatableMixin {
   SomeQuery$Result();
 
   factory SomeQuery$Result.fromJson(Map<String, dynamic> json) =>
@@ -599,7 +600,7 @@ import 'package:decimal/decimal.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$SomeObject with EquatableMixin {
+class SomeQuery$SomeObject extends JsonSerializable with EquatableMixin {
   SomeQuery$SomeObject();
 
   factory SomeQuery$SomeObject.fromJson(Map<String, dynamic> json) =>
@@ -661,7 +662,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class PascalCasingQuery$PascalCasingQuery with EquatableMixin {
+class PascalCasingQuery$PascalCasingQuery extends JsonSerializable
+    with EquatableMixin {
   PascalCasingQuery$PascalCasingQuery();
 
   factory PascalCasingQuery$PascalCasingQuery.fromJson(

--- a/test/query_generator/scalars/custom_scalars_test.dart
+++ b/test/query_generator/scalars/custom_scalars_test.dart
@@ -188,7 +188,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Query$SomeObject with EquatableMixin {
+class Query$SomeObject extends JsonSerializable with EquatableMixin {
   Query$SomeObject();
 
   factory Query$SomeObject.fromJson(Map<String, dynamic> json) =>
@@ -212,7 +212,7 @@ import 'package:example/src/custom_parser.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Query$SomeObject with EquatableMixin {
+class Query$SomeObject extends JsonSerializable with EquatableMixin {
   Query$SomeObject();
 
   factory Query$SomeObject.fromJson(Map<String, dynamic> json) =>
@@ -240,7 +240,7 @@ import 'package:example/src/custom_parser.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Query$SomeObject with EquatableMixin {
+class Query$SomeObject extends JsonSerializable with EquatableMixin {
   Query$SomeObject();
 
   factory Query$SomeObject.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/scalars/scalars_test.dart
+++ b/test/query_generator/scalars/scalars_test.dart
@@ -114,7 +114,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$SomeObject with EquatableMixin {
+class SomeQuery$SomeObject extends JsonSerializable with EquatableMixin {
   SomeQuery$SomeObject();
 
   factory SomeQuery$SomeObject.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/scalars/unused_custom_scalars_test.dart
+++ b/test/query_generator/scalars/unused_custom_scalars_test.dart
@@ -70,7 +70,7 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class Query$SomeObject with EquatableMixin {
+class Query$SomeObject extends JsonSerializable with EquatableMixin {
   Query$SomeObject();
 
   factory Query$SomeObject.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/subscription_test.dart
+++ b/test/query_generator/subscription_test.dart
@@ -142,7 +142,8 @@ import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
 @JsonSerializable(explicitToJson: true)
-class NewUserSub$Subscription$User with EquatableMixin {
+class NewUserSub$Subscription$User extends JsonSerializable
+    with EquatableMixin {
   NewUserSub$Subscription$User();
 
   factory NewUserSub$Subscription$User.fromJson(Map<String, dynamic> json) =>
@@ -161,7 +162,7 @@ class NewUserSub$Subscription$User with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class NewUserSub$Subscription with EquatableMixin {
+class NewUserSub$Subscription extends JsonSerializable with EquatableMixin {
   NewUserSub$Subscription();
 
   factory NewUserSub$Subscription.fromJson(Map<String, dynamic> json) =>

--- a/test/query_generator/union_types_test.dart
+++ b/test/query_generator/union_types_test.dart
@@ -305,7 +305,8 @@ class SomeQuery$SomeObject$SomeUnion$TypeB
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$SomeObject$SomeUnion with EquatableMixin {
+class SomeQuery$SomeObject$SomeUnion extends JsonSerializable
+    with EquatableMixin {
   SomeQuery$SomeObject$SomeUnion();
 
   factory SomeQuery$SomeObject$SomeUnion.fromJson(Map<String, dynamic> json) {
@@ -337,7 +338,7 @@ class SomeQuery$SomeObject$SomeUnion with EquatableMixin {
 }
 
 @JsonSerializable(explicitToJson: true)
-class SomeQuery$SomeObject with EquatableMixin {
+class SomeQuery$SomeObject extends JsonSerializable with EquatableMixin {
   SomeQuery$SomeObject();
 
   factory SomeQuery$SomeObject.fromJson(Map<String, dynamic> json) =>


### PR DESCRIPTION
**Make sure you're opening this pull request pointing to beta branch!**

## What does this PR do/solve?

This adds `extends JsonSerializable` to all classes except for classes that are part of a union type. For union types, the base union type class will extend `JsonSerializable` so each instance can also be treated as `JsonSerializable`. These classes already define a `toJson` and `fromJson` methods. This just adds the `extends` so they can be used in places where something needs to be json serializable. 

See #257 for more details