### PR TITLE
Fix Pokemon example endpoint URL

### DIFF
--- a/example/pokemon/lib/main.dart
+++ b/example/pokemon/lib/main.dart
@@ -7,7 +7,7 @@ import 'graphql/simple_query.dart';
 
 Future<void> main() async {
   final client = ArtemisClient(
-    'https://graphql-pokemon.now.sh/graphql',
+    'https://graphql-pokemon2.vercel.app',
   );
 
   final simpleQuery = SimpleQueryQuery();


### PR DESCRIPTION

## What does this PR do/solve?

In the Pokemon example, the GraphQL endpoint used is no longer available.
I replaced it with a new URL that works for now.
