### PR TITLE
Add "defaultHeaders" to the Artemis client

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -25,10 +25,12 @@ class ArtemisClient {
   /// To use different [Link] create an [ArtemisClient] with [ArtemisClient.fromLink].
   factory ArtemisClient(
     String graphQLEndpoint, {
+    Map<String, String> defaultHeaders,
     http.Client httpClient,
   }) {
     final httpLink = HttpLink(
       graphQLEndpoint,
+      defaultHeaders: defaultHeaders,
       httpClient: httpClient,
     );
     return ArtemisClient.fromLink(


### PR DESCRIPTION
**Make sure you're opening this pull request pointing to beta branch!**

## What does this PR do/solve?

Create the ability to add custom headers to the HTTP request(s). I use this in my own project(s) to add Authorization headers containing JWT tokens.