### PR TITLE
Propagate response context to GraphQLResponse.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 7.0.0-beta.2
+- Add context property to `GraphQLResponse`, propagated from `Response.context`. 
+
 ## 7.0.0-beta.1
 **MAJOR BREAKING CHANGE**
 

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -59,6 +59,7 @@ class ArtemisClient {
     return GraphQLResponse<T>(
       data: response.data == null ? null : query.parse(response.data),
       errors: response.errors,
+      context: response.context,
     );
   }
 
@@ -77,6 +78,7 @@ class ArtemisClient {
     return _link.request(request).map((response) => GraphQLResponse<T>(
           data: response.data == null ? null : query.parse(response.data),
           errors: response.errors,
+          context: response.context,
         ));
   }
 

--- a/lib/schema/graphql_response.dart
+++ b/lib/schema/graphql_response.dart
@@ -13,6 +13,9 @@ class GraphQLResponse<T> {
   /// The list of errors in this response.
   final List<GraphQLError> errors;
 
+  /// Additional context for this response.
+  final Context context;
+
   /// If this response has any error.
   bool get hasErrors => errors != null && errors.isNotEmpty;
 
@@ -20,5 +23,6 @@ class GraphQLResponse<T> {
   const GraphQLResponse({
     this.data,
     this.errors,
+    this.context,
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 7.0.0-beta.1
+version: 7.0.0-beta.2
 
 description: Build dart types from GraphQL schemas and queries (using Introspection Query).
 homepage: https://github.com/comigor/artemis


### PR DESCRIPTION
Propagate response context to GraphQLResponse.

Context contains extra information that can be useful, in particular with https://github.com/gql-dart/gql/pull/205, this would allow obtaining the request ID so you can stop a subscription.