### PR TITLE
feat: Improve support for nested fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 7.0.0-beta.12
+
+- support inline fragments in fragment definitions
+
 ## 7.0.0-beta.11
 
 - document generation fix for https://github.com/comigor/artemis/issues/307

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -329,7 +329,7 @@ Make sure your query is correct and your schema is updated.''');
         nextFieldName: nextFieldName,
         nextClassName: ClassName(name: nextType.name.value),
         alias: fieldAlias,
-        ofUnion: Nullable<TypeDefinitionNode?>(null),
+        ofUnion: Nullable<Name?>(null),
       ),
     );
   }

--- a/lib/generator/data/class_definition.dart
+++ b/lib/generator/data/class_definition.dart
@@ -11,7 +11,7 @@ class ClassDefinition extends Definition with DataPrinter {
   final Iterable<ClassProperty> properties;
 
   /// The type this class extends from, or [null].
-  final Name? extension;
+  final ClassName? extension;
 
   /// The types this class implements.
   final Iterable<String> implementations;

--- a/lib/generator/data/fragment_class_definition.dart
+++ b/lib/generator/data/fragment_class_definition.dart
@@ -15,8 +15,8 @@ class FragmentClassDefinition extends Definition with DataPrinter {
   /// Instantiate a fragment class definition.
   FragmentClassDefinition({
     required this.name,
-    required this.properties,
-  })   : assert(hasValue(name) && hasValue(properties)),
+    this.properties = const [],
+  })  : assert(hasValue(name.name)),
         super(name: name);
 
   @override

--- a/lib/generator/ephemeral_data.dart
+++ b/lib/generator/ephemeral_data.dart
@@ -74,7 +74,7 @@ class Context {
   final Name? currentFieldName;
 
   /// If part of an union type, which [TypeDefinitionNode] it represents.
-  final TypeDefinitionNode? ofUnion;
+  final Name? ofUnion;
 
   /// A string to replace the current class name.
   final Name? alias;
@@ -114,7 +114,7 @@ class Context {
     required TypeDefinitionNode nextType,
     required Name? nextFieldName,
     required Name? nextClassName,
-    Nullable<TypeDefinitionNode?>? ofUnion,
+    Nullable<Name?>? ofUnion,
     Name? alias,
     List<Definition>? generatedClasses,
     List<QueryInput>? inputsClasses,
@@ -143,7 +143,7 @@ class Context {
     Name? nextFieldName,
     Name? nextClassName,
     Name? alias,
-    Nullable<TypeDefinitionNode?>? ofUnion,
+    Nullable<Name?>? ofUnion,
     List<Definition>? generatedClasses,
     List<QueryInput>? inputsClasses,
     List<FragmentDefinitionNode>? fragments,
@@ -203,7 +203,7 @@ class Context {
     Name? nextFieldName,
     Name? nextClassName,
     Name? alias,
-    Nullable<TypeDefinitionNode?>? ofUnion,
+    Nullable<Name?>? ofUnion,
     List<Definition>? generatedClasses,
     List<QueryInput>? inputsClasses,
     List<FragmentDefinitionNode>? fragments,
@@ -261,7 +261,7 @@ class Context {
   /// Returns a copy of this context, with the same type, but on the first path.
   Context sameTypeWithNoPath({
     Name? alias,
-    Nullable<TypeDefinitionNode?>? ofUnion,
+    Nullable<Name?>? ofUnion,
     List<Definition>? generatedClasses,
     List<QueryInput>? inputsClasses,
     List<FragmentDefinitionNode>? fragments,
@@ -289,7 +289,7 @@ class Context {
     required TypeDefinitionNode nextType,
     required Name nextFieldName,
     required Name nextClassName,
-    Nullable<TypeDefinitionNode?>? ofUnion,
+    Nullable<Name?>? ofUnion,
     Name? alias,
     List<Definition>? generatedClasses,
     List<QueryInput>? inputsClasses,

--- a/lib/visitor/canonical_visitor.dart
+++ b/lib/visitor/canonical_visitor.dart
@@ -29,7 +29,7 @@ class CanonicalVisitor extends RecursiveVisitor {
 
     final nextContext = context.sameTypeWithNoPath(
       alias: enumName,
-      ofUnion: Nullable<TypeDefinitionNode?>(null),
+      ofUnion: Nullable<Name?>(null),
     );
 
     logFn(context, nextContext.align, '-> Enum');
@@ -53,7 +53,7 @@ class CanonicalVisitor extends RecursiveVisitor {
     final name = ClassName(name: node.name.value);
     final nextContext = context.sameTypeWithNoPath(
       alias: name,
-      ofUnion: Nullable<TypeDefinitionNode?>(null),
+      ofUnion: Nullable<Name?>(null),
     );
 
     logFn(context, nextContext.align, '-> Input class');
@@ -69,7 +69,7 @@ class CanonicalVisitor extends RecursiveVisitor {
           nextType: node,
           nextClassName: ClassName(name: nextType.name.value),
           nextFieldName: ClassName(name: i.name.value),
-          ofUnion: Nullable<TypeDefinitionNode?>(null),
+          ofUnion: Nullable<Name?>(null),
         ),
         markAsUsed: false,
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 7.0.0-beta.11
+version: 7.0.0-beta.12
 
 description: Build dart types from GraphQL schemas and queries (using Introspection Query).
 homepage: https://github.com/comigor/artemis

--- a/test/query_generator/fragments/inline_fragments_on_fragments.dart
+++ b/test/query_generator/fragments/inline_fragments_on_fragments.dart
@@ -9,11 +9,26 @@ void main() {
       'Interface fragments',
       () async => testGenerator(
         query: r'''
+          fragment InterfaceFragment2 on InterfaceA { 
+            interface {
+              s
+            }
+
+            ...on ImplementationA {
+              b
+            }
+            ...on ImplementationB {
+              i2
+            }
+          }
           fragment InterfaceFragment on InterfaceA { 
             s
             i
             ...on ImplementationA {
               b
+              interface {
+                ...InterfaceFragment2
+              }
             }
             ...on ImplementationB {
               i2
@@ -46,6 +61,7 @@ void main() {
           interface InterfaceA {
             s: String
             i: Int
+            interface: InterfaceA
           }
 
           union UnionA = ImplementationA | ImplementationB
@@ -54,11 +70,13 @@ void main() {
             s: String
             i: Int
             b: Boolean
+            interface: InterfaceA
           }
           type ImplementationB implements InterfaceA {
             s: String
             i: Int
             i2: Int
+            interface: InterfaceA
           }
 
         ''',
@@ -76,11 +94,69 @@ final LibraryDefinition libraryDefinition =
       operationName: r'some_query',
       classes: [
         ClassDefinition(
+            name: ClassName(name: r'InterfaceFragment2Mixin$_InterfaceA'),
+            properties: [
+              ClassProperty(
+                  type: TypeName(name: r'String'),
+                  name: ClassPropertyName(name: r's'),
+                  isResolveType: false)
+            ],
+            factoryPossibilities: {},
+            typeNameField: ClassPropertyName(name: r'__typename'),
+            isInput: false),
+        ClassDefinition(
+            name: ClassName(name: r'InterfaceFragment2Mixin$_ImplementationA'),
+            properties: [
+              ClassProperty(
+                  type: TypeName(name: r'bool'),
+                  name: ClassPropertyName(name: r'b'),
+                  isResolveType: false)
+            ],
+            mixins: [FragmentName(name: r'InterfaceFragment2Mixin')],
+            factoryPossibilities: {},
+            typeNameField: ClassPropertyName(name: r'__typename'),
+            isInput: false),
+        ClassDefinition(
+            name: ClassName(name: r'InterfaceFragment2Mixin$_ImplementationB'),
+            properties: [
+              ClassProperty(
+                  type: TypeName(name: r'int'),
+                  name: ClassPropertyName(name: r'i2'),
+                  isResolveType: false)
+            ],
+            mixins: [FragmentName(name: r'InterfaceFragment2Mixin')],
+            factoryPossibilities: {},
+            typeNameField: ClassPropertyName(name: r'__typename'),
+            isInput: false),
+        FragmentClassDefinition(
+            name: FragmentName(name: r'InterfaceFragment2Mixin'),
+            properties: [
+              ClassProperty(
+                  type: TypeName(name: r'InterfaceFragment2Mixin$_InterfaceA'),
+                  name: ClassPropertyName(name: r'interface'),
+                  annotations: [r'''JsonKey(name: 'interface')'''],
+                  isResolveType: false)
+            ]),
+        ClassDefinition(
+            name: ClassName(
+                name: r'InterfaceFragmentMixin$_ImplementationA$_InterfaceA'),
+            mixins: [FragmentName(name: r'InterfaceFragment2Mixin')],
+            factoryPossibilities: {},
+            typeNameField: ClassPropertyName(name: r'__typename'),
+            isInput: false),
+        ClassDefinition(
             name: ClassName(name: r'InterfaceFragmentMixin$_ImplementationA'),
             properties: [
               ClassProperty(
                   type: TypeName(name: r'bool'),
                   name: ClassPropertyName(name: r'b'),
+                  isResolveType: false),
+              ClassProperty(
+                  type: TypeName(
+                      name:
+                          r'InterfaceFragmentMixin$_ImplementationA$_InterfaceA'),
+                  name: ClassPropertyName(name: r'interface'),
+                  annotations: [r'''JsonKey(name: 'interface')'''],
                   isResolveType: false)
             ],
             mixins: [FragmentName(name: r'InterfaceFragmentMixin')],
@@ -178,11 +254,81 @@ import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
 part 'query.graphql.g.dart';
 
+mixin InterfaceFragment2Mixin {
+  @JsonKey(name: 'interface')
+  InterfaceFragment2Mixin$InterfaceA? kw$interface;
+}
 mixin InterfaceFragmentMixin {
   String? s;
   int? i;
 }
 mixin UnionFragmentMixin {}
+
+@JsonSerializable(explicitToJson: true)
+class InterfaceFragment2Mixin$InterfaceA extends JsonSerializable
+    with EquatableMixin {
+  InterfaceFragment2Mixin$InterfaceA();
+
+  factory InterfaceFragment2Mixin$InterfaceA.fromJson(
+          Map<String, dynamic> json) =>
+      _$InterfaceFragment2Mixin$InterfaceAFromJson(json);
+
+  String? s;
+
+  @override
+  List<Object?> get props => [s];
+  Map<String, dynamic> toJson() =>
+      _$InterfaceFragment2Mixin$InterfaceAToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class InterfaceFragment2Mixin$ImplementationA extends JsonSerializable
+    with EquatableMixin, InterfaceFragment2Mixin {
+  InterfaceFragment2Mixin$ImplementationA();
+
+  factory InterfaceFragment2Mixin$ImplementationA.fromJson(
+          Map<String, dynamic> json) =>
+      _$InterfaceFragment2Mixin$ImplementationAFromJson(json);
+
+  bool? b;
+
+  @override
+  List<Object?> get props => [kw$interface, b];
+  Map<String, dynamic> toJson() =>
+      _$InterfaceFragment2Mixin$ImplementationAToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class InterfaceFragment2Mixin$ImplementationB extends JsonSerializable
+    with EquatableMixin, InterfaceFragment2Mixin {
+  InterfaceFragment2Mixin$ImplementationB();
+
+  factory InterfaceFragment2Mixin$ImplementationB.fromJson(
+          Map<String, dynamic> json) =>
+      _$InterfaceFragment2Mixin$ImplementationBFromJson(json);
+
+  int? i2;
+
+  @override
+  List<Object?> get props => [kw$interface, i2];
+  Map<String, dynamic> toJson() =>
+      _$InterfaceFragment2Mixin$ImplementationBToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class InterfaceFragmentMixin$ImplementationA$InterfaceA extends JsonSerializable
+    with EquatableMixin, InterfaceFragment2Mixin {
+  InterfaceFragmentMixin$ImplementationA$InterfaceA();
+
+  factory InterfaceFragmentMixin$ImplementationA$InterfaceA.fromJson(
+          Map<String, dynamic> json) =>
+      _$InterfaceFragmentMixin$ImplementationA$InterfaceAFromJson(json);
+
+  @override
+  List<Object?> get props => [kw$interface];
+  Map<String, dynamic> toJson() =>
+      _$InterfaceFragmentMixin$ImplementationA$InterfaceAToJson(this);
+}
 
 @JsonSerializable(explicitToJson: true)
 class InterfaceFragmentMixin$ImplementationA extends JsonSerializable
@@ -195,8 +341,11 @@ class InterfaceFragmentMixin$ImplementationA extends JsonSerializable
 
   bool? b;
 
+  @JsonKey(name: 'interface')
+  InterfaceFragmentMixin$ImplementationA$InterfaceA? kw$interface;
+
   @override
-  List<Object?> get props => [s, i, b];
+  List<Object?> get props => [s, i, b, kw$interface];
   Map<String, dynamic> toJson() =>
       _$InterfaceFragmentMixin$ImplementationAToJson(this);
 }

--- a/test/query_generator/fragments/inline_fragments_on_fragments.dart
+++ b/test/query_generator/fragments/inline_fragments_on_fragments.dart
@@ -1,0 +1,297 @@
+import 'package:artemis/generator/data/data.dart';
+import 'package:test/test.dart';
+
+import '../../helpers.dart';
+
+void main() {
+  group('On inline fragments on fragments', () {
+    test(
+      'Interface fragments',
+      () async => testGenerator(
+        query: r'''
+          fragment InterfaceFragment on InterfaceA { 
+            s
+            i
+            ...on ImplementationA {
+              b
+            }
+            ...on ImplementationB {
+              i2
+            }
+          }
+          fragment UnionFragment on UnionA { 
+            ...on ImplementationA {
+              b
+            }
+            ...on ImplementationB {
+              s
+            }
+
+          }
+          query some_query { 
+            interface {
+              ...InterfaceFragment
+            }
+            union {
+              ...UnionFragment
+            }
+          }
+        ''',
+        schema: r'''
+          type Query { 
+            interface: InterfaceA
+            union: UnionA
+          } 
+          
+          interface InterfaceA {
+            s: String
+            i: Int
+          }
+
+          union UnionA = ImplementationA | ImplementationB
+
+          type ImplementationA implements InterfaceA {
+            s: String
+            i: Int
+            b: Boolean
+          }
+          type ImplementationB implements InterfaceA {
+            s: String
+            i: Int
+            i2: Int
+          }
+
+        ''',
+        libraryDefinition: libraryDefinition,
+        generatedFile: generatedFile,
+      ),
+    );
+  });
+}
+
+final LibraryDefinition libraryDefinition =
+    LibraryDefinition(basename: r'query.graphql', queries: [
+  QueryDefinition(
+      name: QueryName(name: r'SomeQuery$_Query'),
+      operationName: r'some_query',
+      classes: [
+        ClassDefinition(
+            name: ClassName(name: r'InterfaceFragmentMixin$_ImplementationA'),
+            properties: [
+              ClassProperty(
+                  type: TypeName(name: r'bool'),
+                  name: ClassPropertyName(name: r'b'),
+                  isResolveType: false)
+            ],
+            mixins: [FragmentName(name: r'InterfaceFragmentMixin')],
+            factoryPossibilities: {},
+            typeNameField: ClassPropertyName(name: r'__typename'),
+            isInput: false),
+        ClassDefinition(
+            name: ClassName(name: r'InterfaceFragmentMixin$_ImplementationB'),
+            properties: [
+              ClassProperty(
+                  type: TypeName(name: r'int'),
+                  name: ClassPropertyName(name: r'i2'),
+                  isResolveType: false)
+            ],
+            mixins: [FragmentName(name: r'InterfaceFragmentMixin')],
+            factoryPossibilities: {},
+            typeNameField: ClassPropertyName(name: r'__typename'),
+            isInput: false),
+        FragmentClassDefinition(
+            name: FragmentName(name: r'InterfaceFragmentMixin'),
+            properties: [
+              ClassProperty(
+                  type: TypeName(name: r'String'),
+                  name: ClassPropertyName(name: r's'),
+                  isResolveType: false),
+              ClassProperty(
+                  type: TypeName(name: r'int'),
+                  name: ClassPropertyName(name: r'i'),
+                  isResolveType: false)
+            ]),
+        ClassDefinition(
+            name: ClassName(name: r'UnionFragmentMixin$_ImplementationA'),
+            properties: [
+              ClassProperty(
+                  type: TypeName(name: r'bool'),
+                  name: ClassPropertyName(name: r'b'),
+                  isResolveType: false)
+            ],
+            mixins: [FragmentName(name: r'UnionFragmentMixin')],
+            factoryPossibilities: {},
+            typeNameField: ClassPropertyName(name: r'__typename'),
+            isInput: false),
+        ClassDefinition(
+            name: ClassName(name: r'UnionFragmentMixin$_ImplementationB'),
+            properties: [
+              ClassProperty(
+                  type: TypeName(name: r'String'),
+                  name: ClassPropertyName(name: r's'),
+                  isResolveType: false)
+            ],
+            mixins: [FragmentName(name: r'UnionFragmentMixin')],
+            factoryPossibilities: {},
+            typeNameField: ClassPropertyName(name: r'__typename'),
+            isInput: false),
+        FragmentClassDefinition(
+            name: FragmentName(name: r'UnionFragmentMixin')),
+        ClassDefinition(
+            name: ClassName(name: r'SomeQuery$_Query$_InterfaceA'),
+            mixins: [FragmentName(name: r'InterfaceFragmentMixin')],
+            factoryPossibilities: {},
+            typeNameField: ClassPropertyName(name: r'__typename'),
+            isInput: false),
+        ClassDefinition(
+            name: ClassName(name: r'SomeQuery$_Query$_UnionA'),
+            mixins: [FragmentName(name: r'UnionFragmentMixin')],
+            factoryPossibilities: {},
+            typeNameField: ClassPropertyName(name: r'__typename'),
+            isInput: false),
+        ClassDefinition(
+            name: ClassName(name: r'SomeQuery$_Query'),
+            properties: [
+              ClassProperty(
+                  type: TypeName(name: r'SomeQuery$_Query$_InterfaceA'),
+                  name: ClassPropertyName(name: r'interface'),
+                  annotations: [r'''JsonKey(name: 'interface')'''],
+                  isResolveType: false),
+              ClassProperty(
+                  type: TypeName(name: r'SomeQuery$_Query$_UnionA'),
+                  name: ClassPropertyName(name: r'union'),
+                  isResolveType: false)
+            ],
+            factoryPossibilities: {},
+            typeNameField: ClassPropertyName(name: r'__typename'),
+            isInput: false)
+      ],
+      generateHelpers: false,
+      suffix: r'Query')
+]);
+
+const generatedFile = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart = 2.12
+
+import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
+import 'package:gql/ast.dart';
+part 'query.graphql.g.dart';
+
+mixin InterfaceFragmentMixin {
+  String? s;
+  int? i;
+}
+mixin UnionFragmentMixin {}
+
+@JsonSerializable(explicitToJson: true)
+class InterfaceFragmentMixin$ImplementationA extends JsonSerializable
+    with EquatableMixin, InterfaceFragmentMixin {
+  InterfaceFragmentMixin$ImplementationA();
+
+  factory InterfaceFragmentMixin$ImplementationA.fromJson(
+          Map<String, dynamic> json) =>
+      _$InterfaceFragmentMixin$ImplementationAFromJson(json);
+
+  bool? b;
+
+  @override
+  List<Object?> get props => [s, i, b];
+  Map<String, dynamic> toJson() =>
+      _$InterfaceFragmentMixin$ImplementationAToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class InterfaceFragmentMixin$ImplementationB extends JsonSerializable
+    with EquatableMixin, InterfaceFragmentMixin {
+  InterfaceFragmentMixin$ImplementationB();
+
+  factory InterfaceFragmentMixin$ImplementationB.fromJson(
+          Map<String, dynamic> json) =>
+      _$InterfaceFragmentMixin$ImplementationBFromJson(json);
+
+  int? i2;
+
+  @override
+  List<Object?> get props => [s, i, i2];
+  Map<String, dynamic> toJson() =>
+      _$InterfaceFragmentMixin$ImplementationBToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class UnionFragmentMixin$ImplementationA extends JsonSerializable
+    with EquatableMixin, UnionFragmentMixin {
+  UnionFragmentMixin$ImplementationA();
+
+  factory UnionFragmentMixin$ImplementationA.fromJson(
+          Map<String, dynamic> json) =>
+      _$UnionFragmentMixin$ImplementationAFromJson(json);
+
+  bool? b;
+
+  @override
+  List<Object?> get props => [b];
+  Map<String, dynamic> toJson() =>
+      _$UnionFragmentMixin$ImplementationAToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class UnionFragmentMixin$ImplementationB extends JsonSerializable
+    with EquatableMixin, UnionFragmentMixin {
+  UnionFragmentMixin$ImplementationB();
+
+  factory UnionFragmentMixin$ImplementationB.fromJson(
+          Map<String, dynamic> json) =>
+      _$UnionFragmentMixin$ImplementationBFromJson(json);
+
+  String? s;
+
+  @override
+  List<Object?> get props => [s];
+  Map<String, dynamic> toJson() =>
+      _$UnionFragmentMixin$ImplementationBToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class SomeQuery$Query$InterfaceA extends JsonSerializable
+    with EquatableMixin, InterfaceFragmentMixin {
+  SomeQuery$Query$InterfaceA();
+
+  factory SomeQuery$Query$InterfaceA.fromJson(Map<String, dynamic> json) =>
+      _$SomeQuery$Query$InterfaceAFromJson(json);
+
+  @override
+  List<Object?> get props => [s, i];
+  Map<String, dynamic> toJson() => _$SomeQuery$Query$InterfaceAToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class SomeQuery$Query$UnionA extends JsonSerializable
+    with EquatableMixin, UnionFragmentMixin {
+  SomeQuery$Query$UnionA();
+
+  factory SomeQuery$Query$UnionA.fromJson(Map<String, dynamic> json) =>
+      _$SomeQuery$Query$UnionAFromJson(json);
+
+  @override
+  List<Object?> get props => [];
+  Map<String, dynamic> toJson() => _$SomeQuery$Query$UnionAToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class SomeQuery$Query extends JsonSerializable with EquatableMixin {
+  SomeQuery$Query();
+
+  factory SomeQuery$Query.fromJson(Map<String, dynamic> json) =>
+      _$SomeQuery$QueryFromJson(json);
+
+  @JsonKey(name: 'interface')
+  SomeQuery$Query$InterfaceA? kw$interface;
+
+  SomeQuery$Query$UnionA? union;
+
+  @override
+  List<Object?> get props => [kw$interface, union];
+  Map<String, dynamic> toJson() => _$SomeQuery$QueryToJson(this);
+}
+''';


### PR DESCRIPTION
**Make sure you're opening this pull request pointing to beta branch!**

## What does this PR do/solve?

This PR improves fragment support.

Given the schema:

```graphql

type Query { 
  interface: InterfaceA
  union: UnionA
} 

interface InterfaceA {
  s: String
  i: Int
}
union UnionA = ImplementationA | ImplementationB
type ImplementationA implements InterfaceA {
  s: String
  i: Int
  b: Boolean
}
type ImplementationB implements InterfaceA {
  s: String
  i: Int
  i2: Int
}
```

and the query

```graphql
fragment InterfaceFragment on InterfaceA { 
  s
  i
  ...on ImplementationA {
    b
  }
  ...on ImplementationB {
    i2
  }
}
fragment UnionFragment on UnionA { 
  ...on ImplementationA {
    b
  }
  ...on ImplementationB {
    s
  }

}
query some_query { 
  interface {
    ...InterfaceFragment
  }
  union {
    ...UnionFragment
  }
}
```

This is an example of what Artemis currently generates:

```dart

@JsonSerializable(explicitToJson: true)
class SomeQuery$Query$InterfaceA extends FileSystemEntryMixin
    with EquatableMixin {
  SomeQuery$Query$InterfaceA();
  factory SomeQuery$Query$InterfaceA.fromJson(Map<String, dynamic> json) =>
      _$SomeQuery$Query$InterfaceAFromJson(json);
  @override
  List<Object?> get props => [s, i];
  Map<String, dynamic> toJson() => _$SomeQuery$Query$InterfaceAToJson(this);
}
```

The code above is not valid Dart code.

Instead, I believe it should be:

```dart

@JsonSerializable(explicitToJson: true)
class SomeQuery$Query$InterfaceA extends JsonSerializable
    with EquatableMixin, InterfaceFragmentMixin {
  SomeQuery$Query$InterfaceA();
  factory SomeQuery$Query$InterfaceA.fromJson(Map<String, dynamic> json) =>
      _$SomeQuery$Query$InterfaceAFromJson(json);
  @override
  List<Object?> get props => [s, i];
  Map<String, dynamic> toJson() => _$SomeQuery$Query$InterfaceAToJson(this);
}
```
