### PR TITLE
Add optional context argument to ArtemisClient

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -40,16 +40,20 @@ class ArtemisClient {
   /// Create an [ArtemisClient] from [Link].
   ArtemisClient.fromLink(this._link);
 
-  /// Executes a [GraphQLQuery], returning a typed response.
+  /// Executes a [GraphQLQuery], returning a typed response. An optional
+  /// [Context] can also be provided to add additional information like
+  /// headers to the query.
   Future<GraphQLResponse<T>> execute<T, U extends JsonSerializable>(
-    GraphQLQuery<T, U> query,
-  ) async {
+    GraphQLQuery<T, U> query, {
+    Context? context,
+  }) async {
     final request = Request(
       operation: Operation(
         document: query.document,
         operationName: query.operationName,
       ),
       variables: query.getVariablesMap(),
+      context: context ?? const Context(),
     );
 
     final response = await _link.request(request).first;
@@ -60,16 +64,20 @@ class ArtemisClient {
     );
   }
 
-  /// Streams a [GraphQLQuery], returning a typed response stream.
+  /// Streams a [GraphQLQuery], returning a typed response stream. An optional
+  /// [Context] can also be provided to add additional information like
+  /// headers to the query.
   Stream<GraphQLResponse<T>> stream<T, U extends JsonSerializable>(
-    GraphQLQuery<T, U> query,
-  ) {
+    GraphQLQuery<T, U> query, {
+    Context? context,
+  }) {
     final request = Request(
       operation: Operation(
         document: query.document,
         operationName: query.operationName,
       ),
       variables: query.getVariablesMap(),
+      context: context ?? const Context(),
     );
 
     return _link.request(request).map((response) => GraphQLResponse<T>(


### PR DESCRIPTION
## What does this PR do/solve?

This non-breaking change to ArtemisClient allows a caller to provide additional `Context` information to queries (on both `execute` or `stream`). 

For example, the following would add a request-specific header to a GraphQL query, just before sending it:

```dart
import 'package:graphql/client.dart' as graphql;

final requestUuid = Uuid().v4();
artemisClient.execute(
  query, 
  context: graphql.Context.fromList([
    graphql.HttpLinkHeaders(headers: {'x-request-id': requestUuid})
  ]),
);
```

/cc @Pacane