### PR TITLE
Accept and return gql context in client's methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 7.0.0-beta.14
+
+- Support gql context in client's execute and stream methods
+
 ## 7.0.0-beta.13
 
 - fix for https://github.com/comigor/artemis/issues/177

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -65,19 +65,22 @@ class ArtemisClient {
 
   /// Streams a [GraphQLQuery], returning a typed response stream.
   Stream<GraphQLResponse<T>> stream<T, U extends JsonSerializable>(
-    GraphQLQuery<T, U> query,
-  ) {
+    GraphQLQuery<T, U> query, {
+    Context context = const Context(),
+  }) {
     final request = Request(
       operation: Operation(
         document: query.document,
         operationName: query.operationName,
       ),
       variables: query.getVariablesMap(),
+      context: context,
     );
 
     return _link.request(request).map((response) => GraphQLResponse<T>(
           data: response.data == null ? null : query.parse(response.data ?? {}),
           errors: response.errors,
+          context: response.context,
         ));
   }
 

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -42,14 +42,16 @@ class ArtemisClient {
 
   /// Executes a [GraphQLQuery], returning a typed response.
   Future<GraphQLResponse<T>> execute<T, U extends JsonSerializable>(
-    GraphQLQuery<T, U> query,
-  ) async {
+    GraphQLQuery<T, U> query, {
+    Context context = const Context(),
+  }) async {
     final request = Request(
       operation: Operation(
         document: query.document,
         operationName: query.operationName,
       ),
       variables: query.getVariablesMap(),
+      context: context,
     );
 
     final response = await _link.request(request).first;
@@ -57,6 +59,7 @@ class ArtemisClient {
     return GraphQLResponse<T>(
       data: response.data == null ? null : query.parse(response.data ?? {}),
       errors: response.errors,
+      context: response.context,
     );
   }
 

--- a/lib/schema/graphql_response.dart
+++ b/lib/schema/graphql_response.dart
@@ -12,9 +12,13 @@ class GraphQLResponse<T> {
   /// If this response has any error.
   bool get hasErrors => errors != null && errors!.isNotEmpty;
 
+  /// The [Context] of the [Response]
+  final Context? context;
+
   /// Instantiates a GraphQL response.
   const GraphQLResponse({
     this.data,
     this.errors,
+    this.context,
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: artemis
-version: 7.0.0-beta.13
+version: 7.0.0-beta.14
 
 description: Build dart types from GraphQL schemas and queries (using Introspection Query).
 homepage: https://github.com/comigor/artemis


### PR DESCRIPTION
## What does this PR do/solve?
Support passing a context when calling [Request](https://github.com/gql-dart/gql/blob/master/links/gql_exec/lib/src/request.dart#L15-L16), in client's `execute` and `stream` methods, and returns the response context as well